### PR TITLE
Fix #404: [Feature] Prevent memory mixing when switching projects in MCP

### DIFF
--- a/docs/memori-cloud/mcp/client-setup.mdx
+++ b/docs/memori-cloud/mcp/client-setup.mdx
@@ -188,6 +188,38 @@ const memoriHeaders = {
 Pass these headers in every MCP tool call. `session_id` is derived automatically from `entity_id` and the current UTC hour.
 Use `process_id` to isolate memories by integration or workspace so preferences from a personal workspace don't bleed into a team workspace.
 
+## Project-Scoped Setup
+
+When you work across multiple projects, use a **per-project `.mcp.json`** so `entity_id` and `process_id` are fixed to that project and never need manual switching.
+
+Place `.mcp.json` in each project root with project-specific values:
+
+```json
+{
+  "mcpServers": {
+    "memori": {
+      "type": "http",
+      "url": "https://api.memorilabs.ai/mcp/",
+      "headers": {
+        "X-Memori-API-Key": "${MEMORI_API_KEY}",
+        "X-Memori-Entity-Id": "project-alpha",
+        "X-Memori-Process-Id": "project-alpha"
+      }
+    }
+  }
+}
+```
+
+Because the values are hardcoded per file, the correct identifiers are loaded automatically whenever you open that project — no manual switching required.
+
+**When to use the same value for both headers:**
+Set `X-Memori-Entity-Id` and `X-Memori-Process-Id` to the same string (e.g. `project-alpha`) when a project has a single agent or workflow. All memories are scoped to that project and shared across sessions.
+
+**When to use different values:**
+Set `X-Memori-Process-Id` to a distinct agent name (e.g. `research-agent`, `review-agent`) when multiple agents share the same project entity. Facts are shared across agents for that entity; conversation history stays isolated per process.
+
+**Keep the API key as an environment variable** — export `MEMORI_API_KEY` once in your shell profile (`.bashrc` / `.zshrc`) and reference it via `${MEMORI_API_KEY}` in every project config.
+
 ## Verifying the Connection
 
 After configuring any client:


### PR DESCRIPTION
Closes #404

Adds a "Project-Scoped Setup" section to `docs/memori-cloud/mcp/client-setup.mdx` that documents per-project `.mcp.json` configuration to prevent memory cross-contamination when switching between projects.

## Changes

**`docs/memori-cloud/mcp/client-setup.mdx`** (+32 lines after line 190):
- New `## Project-Scoped Setup` section inserted between the existing headers usage explanation and the `## Verifying the Connection` section.
- Introduces a `.mcp.json` snippet with hardcoded `X-Memori-Entity-Id` and `X-Memori-Process-Id` values and an `${MEMORI_API_KEY}` env-var reference, demonstrating placement at the project root.
- Adds inline guidance on when both headers should share the same value (single-agent project) versus differ (multiple agents sharing one entity but needing isolated conversation history per process).
- Adds a callout to keep the API key in the shell profile and reference it via `${MEMORI_API_KEY}` across all project configs.

## Motivation

Users working across multiple projects must manually update `X-Memori-Entity-Id` and `X-Memori-Process-Id` in their MCP client config on every context switch. Forgetting to do so causes memories from different projects to bleed into each other. By placing a `.mcp.json` at each project root with fixed identifiers, the correct scope is loaded automatically by the MCP client without any manual intervention. The existing docs covered header semantics but gave no guidance on per-project config layout.

## Testing

- Rendered the MDX locally and confirmed the new section appears between the headers usage paragraph and `## Verifying the Connection` with correct heading hierarchy.
- Validated the JSON snippet is well-formed.
- Confirmed `${MEMORI_API_KEY}` substitution matches the pattern already used in earlier examples in the same file.
- No code changes; testing consists of doc render verification and a manual walkthrough of the `.mcp.json` snippet in a Claude Desktop project directory to confirm the headers are picked up correctly without editing the global config.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*