### PR TITLE
docs: add project-scoped MCP attribution guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added MCP client setup guidance for project-scoped attribution using workspace-derived values for `X-Memori-Entity-Id` and `X-Memori-Process-Id` to prevent memory mixing across projects. (Refs #404)
+
 ## [3.3.2] - 2026-04-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added MCP client setup guidance for project-scoped attribution using workspace-derived values for `X-Memori-Entity-Id` and `X-Memori-Process-Id` to prevent memory mixing across projects. (Refs #404)
+
 ### Fixed
 
 - Fixed multi-turn conversation ingestion for AzureOpenAI and OpenAI clients. Previously, only the first conversation turn was being recorded. Now `conversation_id` is resolved early in the request lifecycle, ensuring all conversation turns are properly ingested into the same conversation. (Fixes #83)

--- a/docs/memori-cloud/mcp/client-setup.mdx
+++ b/docs/memori-cloud/mcp/client-setup.mdx
@@ -30,9 +30,9 @@ Create `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project-level):
     "memori": {
       "url": "https://api.memorilabs.ai/mcp/",
       "headers": {
-        "X-Memori-API-Key": "${MEMORI_API_KEY}",
-        "X-Memori-Entity-Id": "${MEMORI_ENTITY_ID}",
-        "X-Memori-Process-Id": "${MEMORI_PROCESS_ID}"
+        "X-Memori-API-Key": "${env:MEMORI_API_KEY}",
+        "X-Memori-Entity-Id": "${env:MEMORI_ENTITY_ID}",
+        "X-Memori-Process-Id": "${env:MEMORI_PROCESS_ID}"
       }
     }
   }
@@ -40,6 +40,29 @@ Create `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project-level):
 ```
 
 Restart Cursor after saving the file.
+
+### Project-Scoped Attribution (Recommended)
+
+When working across multiple repositories, derive both attribution headers from the active workspace to avoid mixing memories across projects:
+
+```json
+{
+  "mcpServers": {
+    "memori": {
+      "url": "https://api.memorilabs.ai/mcp/",
+      "headers": {
+        "X-Memori-API-Key": "${env:MEMORI_API_KEY}",
+        "X-Memori-Entity-Id": "${workspaceFolderBasename}",
+        "X-Memori-Process-Id": "${workspaceFolderBasename}"
+      }
+    }
+  }
+}
+```
+
+If your MCP client does not support workspace placeholders, set equivalent values with environment variables before launching the client.
+
+**Same value vs. different values.** Use the **same** value for `X-Memori-Entity-Id` and `X-Memori-Process-Id` when each project has a single agent and you want one isolated memory scope per project (the common case for the snippet above). Use **different** values when several agents share one entity but each agent needs its own isolated conversation history: keep `X-Memori-Entity-Id` as a stable user/team identifier (for example `user_123` or `${env:MEMORI_ENTITY_ID}`) and let `X-Memori-Process-Id` vary per workspace, agent, or integration (for example `${workspaceFolderBasename}` or `cursor-web-app`).
 
 ## Claude Code
 

--- a/docs/memori-cloud/mcp/client-setup.mdx
+++ b/docs/memori-cloud/mcp/client-setup.mdx
@@ -41,6 +41,27 @@ Create `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project-level):
 
 Restart Cursor after saving the file.
 
+### Project-Scoped Attribution (Recommended)
+
+When working across multiple repositories, derive both attribution headers from the active workspace to avoid mixing memories across projects:
+
+```json
+{
+  "mcpServers": {
+    "memori": {
+      "url": "https://api.memorilabs.ai/mcp/",
+      "headers": {
+        "X-Memori-API-Key": "${MEMORI_API_KEY}",
+        "X-Memori-Entity-Id": "${workspaceFolderBasename}",
+        "X-Memori-Process-Id": "${workspaceFolderBasename}"
+      }
+    }
+  }
+}
+```
+
+If your MCP client does not support workspace placeholders, set equivalent values with environment variables before launching the client.
+
 ## Claude Code
 
 You can configure via the CLI or a `.mcp.json` file.


### PR DESCRIPTION
## Summary
- add a recommended project-scoped Cursor MCP example using workspace-derived values
- document how to avoid manually switching `X-Memori-Entity-Id` and `X-Memori-Process-Id` across many projects
- add an Unreleased changelog entry for the MCP docs improvement

## Test plan
- [x] docs content reviewed for consistency with existing MCP header naming
- [x] markdown formatting validated in edited files
- [ ] maintainers verify behavior in supported MCP clients

Closes #404

Made with [Cursor](https://cursor.com)