### PR TITLE
Lazy-init native engine and add sync-native --dev

### DIFF
--- a/memori-ts/package-lock.json
+++ b/memori-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memorilabs/memori",
-  "version": "0.1.9-beta",
+  "version": "0.1.10-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorilabs/memori",
-      "version": "0.1.9-beta",
+      "version": "0.1.10-beta",
       "license": "Apache-2.0",
       "dependencies": {
         "@memorilabs/axon": "^0.1.5"

--- a/memori-ts/package.json
+++ b/memori-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorilabs/memori",
-  "version": "0.1.9-beta",
+  "version": "0.1.10-beta",
   "description": "The official TypeScript SDK for Memori",
   "type": "module",
   "main": "./dist/index.js",
@@ -27,9 +27,10 @@
   "scripts": {
     "preversion": "npm run sync-versions",
     "sync-native": "node scripts/sync-native.js",
+    "sync-native:dev": "node scripts/sync-native.js --dev",
     "sync-versions": "node scripts/bump-versions.js",
     "build": "tsc -p tsconfig.build.json",
-    "build:dev": "npm run sync-native && tsc -p tsconfig.json",
+    "build:dev": "npm run sync-native:dev && tsc -p tsconfig.json",
     "memori": "node dist/bin/cli.js",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",

--- a/memori-ts/scripts/sync-native.js
+++ b/memori-ts/scripts/sync-native.js
@@ -7,7 +7,12 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
 const RUST_BINDINGS_DIR = path.resolve(ROOT, '../core/bindings/node');
 const SRC_NATIVE = path.resolve(ROOT, 'src/native');
-const DIST_NATIVE = path.resolve(ROOT, 'dist/native');
+
+// CHECK FOR FLAG: Did we run this with "node scripts/sync-native.js --dev"?
+const isDev = process.argv.includes('--dev');
+
+// Set target dynamically based on the flag
+const DIST_NATIVE = path.resolve(ROOT, isDev ? 'dist/src/native' : 'dist/native');
 
 function copyFolderSync(from, to) {
   if (!fs.existsSync(from)) return;
@@ -38,7 +43,8 @@ function sync() {
   console.log('Syncing to src/native...');
   copyFolderSync(RUST_BINDINGS_DIR, SRC_NATIVE);
 
-  console.log('Syncing to dist/src/native...');
+  // Copy to the single correct distribution folder
+  console.log(`Syncing to ${isDev ? 'dist/src/native (Dev)' : 'dist/native (Prd)'}...`);
   copyFolderSync(SRC_NATIVE, DIST_NATIVE);
 
   console.log('Native sync complete.');

--- a/memori-ts/src/core/engine.ts
+++ b/memori-ts/src/core/engine.ts
@@ -9,109 +9,120 @@ import {
 import { RetrievalRequest, RecallObject, NapiRecallRow } from '../types/api.js';
 import { AugmentationInput } from '../types/integrations.js';
 
+type BridgeCb = (err: Error | null, _id: number, _reqJson: string) => void;
+
 export class NativeEngine {
   private memoriEngine?: MemoriEngine;
   private _hasStorage: boolean = false;
+  private readonly modelName: string | null;
+  private readonly fetchEmbeddingsCb: BridgeCb;
+  private readonly fetchFactsCb: BridgeCb;
+  private readonly writeBatchCb: BridgeCb;
 
   constructor(storageBridge?: StorageBridge, modelName?: string) {
+    this.modelName = modelName ?? null;
+
     if (storageBridge) {
       this._hasStorage = true;
-      this.memoriEngine = new MemoriEngine(
-        modelName || null,
-        (err: Error | null, _id: number, _reqJson: string) => {
-          if (err) {
-            console.error('[Memori] Bridge error in fetchEmbeddings:', err);
-            return;
-          }
-          const [id, reqJson] = (Array.isArray(_id) ? _id : [_id, _reqJson]) as [number, string];
 
-          this.handleBridgeCall<EmbeddingRow[]>(
-            id,
-            'fetchEmbeddings',
-            () => {
-              const req = JSON.parse(reqJson) as { entity_id: string; limit: number };
-              return storageBridge.fetchEmbeddings(req.entity_id, req.limit);
-            },
-            (res) =>
-              this.memoriEngine?.resolveEmbeddingsCallback(
-                id,
-                res.map((r) => ({
-                  id: r.id,
-                  contentEmbedding: r.content_embedding ?? new Float32Array(0),
-                }))
-              ),
-            () => this.memoriEngine?.resolveEmbeddingsCallback(id, [])
-          );
-        },
-        (err: Error | null, _id: number, _reqJson: string) => {
-          if (err) {
-            console.error('[Memori] Bridge error in fetchFactsByIds:', err);
-            return;
-          }
-          const [id, reqJson] = (Array.isArray(_id) ? _id : [_id, _reqJson]) as [number, string];
-
-          this.handleBridgeCall<CandidateFactRow[]>(
-            id,
-            'fetchFactsByIds',
-            () => {
-              const req = JSON.parse(reqJson) as { ids: (number | string)[] };
-              return storageBridge.fetchFactsByIds(req.ids);
-            },
-            (res) =>
-              this.memoriEngine?.resolveFactsCallback(
-                id,
-                res.map((r) => ({
-                  id: r.id,
-                  content: r.content,
-                  dateCreated: r.date_created,
-                  summaries: r.summaries?.map((s) => ({
-                    content: s.content,
-                    dateCreated: s.date_created,
-                  })),
-                }))
-              ),
-            () => this.memoriEngine?.resolveFactsCallback(id, [])
-          );
-        },
-        (err: Error | null, _id: number, _reqJson: string) => {
-          if (err) {
-            console.error('[Memori] Bridge error in writeBatch:', err);
-            return;
-          }
-          const [id, reqJson] = (Array.isArray(_id) ? _id : [_id, _reqJson]) as [number, string];
-
-          this.handleBridgeCall<WriteAck>(
-            id,
-            'writeBatch',
-            () => {
-              const req = JSON.parse(reqJson) as WriteBatch;
-              return storageBridge.writeBatch(req);
-            },
-            (res) => this.memoriEngine?.resolveWriteCallback(id, { writtenOps: res.written_ops }),
-            () => this.memoriEngine?.resolveWriteCallback(id, { writtenOps: 0 })
-          );
+      this.fetchEmbeddingsCb = (err, _id, _reqJson) => {
+        if (err) {
+          console.error('[Memori] Bridge error in fetchEmbeddings:', err);
+          return;
         }
-      );
+        const [id, reqJson] = (Array.isArray(_id) ? _id : [_id, _reqJson]) as [number, string];
+        this.handleBridgeCall<EmbeddingRow[]>(
+          id,
+          'fetchEmbeddings',
+          () => {
+            const req = JSON.parse(reqJson) as { entity_id: string; limit: number };
+            return storageBridge.fetchEmbeddings(req.entity_id, req.limit);
+          },
+          (res) =>
+            this.memoriEngine?.resolveEmbeddingsCallback(
+              id,
+              res.map((r) => ({
+                id: r.id,
+                contentEmbedding: r.content_embedding ?? new Float32Array(0),
+              }))
+            ),
+          () => this.memoriEngine?.resolveEmbeddingsCallback(id, [])
+        );
+      };
 
-      return;
-    }
+      this.fetchFactsCb = (err, _id, _reqJson) => {
+        if (err) {
+          console.error('[Memori] Bridge error in fetchFactsByIds:', err);
+          return;
+        }
+        const [id, reqJson] = (Array.isArray(_id) ? _id : [_id, _reqJson]) as [number, string];
+        this.handleBridgeCall<CandidateFactRow[]>(
+          id,
+          'fetchFactsByIds',
+          () => {
+            const req = JSON.parse(reqJson) as { ids: (number | string)[] };
+            return storageBridge.fetchFactsByIds(req.ids);
+          },
+          (res) =>
+            this.memoriEngine?.resolveFactsCallback(
+              id,
+              res.map((r) => ({
+                id: r.id,
+                content: r.content,
+                dateCreated: r.date_created,
+                summaries: r.summaries?.map((s) => ({
+                  content: s.content,
+                  dateCreated: s.date_created,
+                })),
+              }))
+            ),
+          () => this.memoriEngine?.resolveFactsCallback(id, [])
+        );
+      };
 
-    // Fallback Engine without Storage
-    this.memoriEngine = new MemoriEngine(
-      modelName || null,
-      (err: Error | null, _id: number, _reqJson: string) => {
+      this.writeBatchCb = (err, _id, _reqJson) => {
+        if (err) {
+          console.error('[Memori] Bridge error in writeBatch:', err);
+          return;
+        }
+        const [id, reqJson] = (Array.isArray(_id) ? _id : [_id, _reqJson]) as [number, string];
+        this.handleBridgeCall<WriteAck>(
+          id,
+          'writeBatch',
+          () => {
+            const req = JSON.parse(reqJson) as WriteBatch;
+            return storageBridge.writeBatch(req);
+          },
+          (res) => this.memoriEngine?.resolveWriteCallback(id, { writtenOps: res.written_ops }),
+          () => this.memoriEngine?.resolveWriteCallback(id, { writtenOps: 0 })
+        );
+      };
+    } else {
+      this.fetchEmbeddingsCb = (err, _id, _reqJson) => {
         const [id] = (Array.isArray(_id) ? _id : [_id, _reqJson]) as [number, string];
         if (!err) this.memoriEngine?.resolveEmbeddingsCallback(id, []);
-      },
-      (err: Error | null, _id: number, _reqJson: string) => {
+      };
+      this.fetchFactsCb = (err, _id, _reqJson) => {
         const [id] = (Array.isArray(_id) ? _id : [_id, _reqJson]) as [number, string];
         if (!err) this.memoriEngine?.resolveFactsCallback(id, []);
-      },
-      (err: Error | null, _id: number, _reqJson: string) => {
+      };
+      this.writeBatchCb = (err, _id, _reqJson) => {
         const [id] = (Array.isArray(_id) ? _id : [_id, _reqJson]) as [number, string];
         if (!err) this.memoriEngine?.resolveWriteCallback(id, { writtenOps: 0 });
-      }
-    );
+      };
+    }
+  }
+
+  private getEngine(): MemoriEngine {
+    if (!this.memoriEngine) {
+      this.memoriEngine = new MemoriEngine(
+        this.modelName,
+        this.fetchEmbeddingsCb,
+        this.fetchFactsCb,
+        this.writeBatchCb
+      );
+    }
+    return this.memoriEngine;
   }
 
   public get hasStorage(): boolean {
@@ -156,9 +167,7 @@ export class NativeEngine {
   }
 
   public async retrieve(request: RetrievalRequest): Promise<RecallObject[]> {
-    if (!this.memoriEngine) throw new Error('Native engine not initialized.');
-
-    const napiResults: NapiRecallRow[] = await this.memoriEngine.retrieve({
+    const napiResults: NapiRecallRow[] = await this.getEngine().retrieve({
       entityId: request.entity_id,
       queryText: request.query_text,
       denseLimit: request.dense_limit,
@@ -182,9 +191,7 @@ export class NativeEngine {
   }
 
   public async recall(request: RetrievalRequest): Promise<string> {
-    if (!this.memoriEngine) throw new Error('Native engine not initialized.');
-
-    return await this.memoriEngine.recall({
+    return await this.getEngine().recall({
       entityId: request.entity_id,
       queryText: request.query_text,
       denseLimit: request.dense_limit,
@@ -193,9 +200,9 @@ export class NativeEngine {
   }
 
   public embedTexts(texts: string[]): Float32Array[] {
-    if (!this.memoriEngine || texts.length === 0) return [];
+    if (texts.length === 0) return [];
     try {
-      return this.memoriEngine.embedTexts(texts);
+      return this.getEngine().embedTexts(texts);
     } catch (e: unknown) {
       console.error('[Memori] Bridge Sync Error (embedTexts):', e);
       return [];
@@ -203,9 +210,7 @@ export class NativeEngine {
   }
 
   public submitAugmentation(input: AugmentationInput): string {
-    if (!this.memoriEngine) throw new Error('Native engine not initialized.');
-
-    return this.memoriEngine.submitAugmentation({
+    return this.getEngine().submitAugmentation({
       entityId: input.entity_id,
       processId: input.process_id ?? undefined,
       conversationId: input.conversation_id ?? undefined,

--- a/memori-ts/src/storage/adapters/drizzle.ts
+++ b/memori-ts/src/storage/adapters/drizzle.ts
@@ -1,4 +1,4 @@
-import { sql, type SQL } from 'drizzle-orm';
+import type { SQL } from 'drizzle-orm';
 import type { StorageAdapter, SqlBindValue } from '../base.js';
 import { Registry } from '../registry.js';
 
@@ -34,6 +34,7 @@ export class DrizzleAdapter implements StorageAdapter {
       );
     }
 
+    const { sql } = await import('drizzle-orm');
     const parts = operation.split(/\$\d+|\?/);
     let query = sql.raw(parts[0] || '');
 
@@ -49,14 +50,17 @@ export class DrizzleAdapter implements StorageAdapter {
   }
 
   public async begin(): Promise<void> {
+    const { sql } = await import('drizzle-orm');
     await this.db.execute(sql`BEGIN`);
   }
 
   public async commit(): Promise<void> {
+    const { sql } = await import('drizzle-orm');
     await this.db.execute(sql`COMMIT`);
   }
 
   public async rollback(): Promise<void> {
+    const { sql } = await import('drizzle-orm');
     await this.db.execute(sql`ROLLBACK`);
   }
 


### PR DESCRIPTION
- Refactor native engine to lazily initialize MemoriEngine via getEngine(), store bridge callbacks as properties, and avoid requiring the native engine to be created up-front. 
- Add support for a --dev flag to scripts/sync-native.js (and new npm script sync-native:dev) so native bindings can be copied to a dev-specific dist path (dist/src/native) or the production path (dist/native). 
- Update package.json to bump version to 0.1.10-beta and wire the new sync-native:dev into build:dev. 
- Change drizzle adapter imports to use a type-only import for SQL and dynamically import sql from drizzle-orm at call sites (BEGIN/COMMIT/ROLLBACK and query building) to avoid top-level import issues.