### PR TITLE
Bump v0.1.11 and use collectorApi for augmentation

### DIFF
--- a/memori-ts/package-lock.json
+++ b/memori-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memorilabs/memori",
-  "version": "0.1.10-beta",
+  "version": "0.1.11-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorilabs/memori",
-      "version": "0.1.10-beta",
+      "version": "0.1.11-beta",
       "license": "Apache-2.0",
       "dependencies": {
         "@memorilabs/axon": "^0.1.5"

--- a/memori-ts/package.json
+++ b/memori-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorilabs/memori",
-  "version": "0.1.10-beta",
+  "version": "0.1.11-beta",
   "description": "The official TypeScript SDK for Memori",
   "type": "module",
   "main": "./dist/index.js",

--- a/memori-ts/src/core/config.ts
+++ b/memori-ts/src/core/config.ts
@@ -83,6 +83,6 @@ export class Config {
     // 3. Session and Defaults
     this.sessionId = randomUUID();
     this.recallRelevanceThreshold = 0.1;
-    this.timeout = 5000;
+    this.timeout = 30000;
   }
 }

--- a/memori-ts/src/engines/augmentation.ts
+++ b/memori-ts/src/engines/augmentation.ts
@@ -74,7 +74,7 @@ export class AugmentationEngine {
     };
 
     // Fire-and-forget to cloud
-    this.defaultApi.post('cloud/augmentation', payload).catch((e: unknown) => {
+    this.collectorApi.post('cloud/augmentation', payload).catch((e: unknown) => {
       if (this.config.testMode) console.warn('Augmentation failed:', e);
     });
 

--- a/memori-ts/tests/engines/augmentation.test.ts
+++ b/memori-ts/tests/engines/augmentation.test.ts
@@ -61,7 +61,7 @@ describe('AugmentationEngine', () => {
 
       await engine.handleAugmentation(req, res, mockCtx);
 
-      expect(mockApi.post).toHaveBeenCalledWith(
+      expect(mockCollectorApi.post).toHaveBeenCalledWith(
         'cloud/augmentation',
         expect.objectContaining({
           conversation: expect.objectContaining({
@@ -97,7 +97,7 @@ describe('AugmentationEngine', () => {
     });
 
     it('should log warning in testMode if API fails', async () => {
-      (mockApi.post as any).mockRejectedValue(new Error('Augment fail'));
+      (mockCollectorApi.post as any).mockRejectedValue(new Error('Augment fail'));
       const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
       const req = {


### PR DESCRIPTION
Bump package version to 0.1.11-beta. Switch AugmentationEngine to post augmentation payloads via collectorApi (fire-and-forget) instead of defaultApi and increase the default timeout from 5000ms to 30000ms to reduce premature timeouts. Update tests to use mockCollectorApi and to assert/log failures against the collector API.