### PR TITLE
Add sign-up CLI command and tests

### DIFF
--- a/memori-ts/package-lock.json
+++ b/memori-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memorilabs/memori",
-  "version": "0.1.11-beta",
+  "version": "0.1.12-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorilabs/memori",
-      "version": "0.1.11-beta",
+      "version": "0.1.12-beta",
       "license": "Apache-2.0",
       "dependencies": {
         "@memorilabs/axon": "^0.1.5"

--- a/memori-ts/package.json
+++ b/memori-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorilabs/memori",
-  "version": "0.1.11-beta",
+  "version": "0.1.12-beta",
   "description": "The official TypeScript SDK for Memori",
   "type": "module",
   "main": "./dist/index.js",

--- a/memori-ts/src/cli/commands/signup.ts
+++ b/memori-ts/src/cli/commands/signup.ts
@@ -1,0 +1,37 @@
+import { Config } from '../../core/config.js';
+import { Api } from '../../core/network.js';
+import { MemoriApiValidationError } from '../../core/errors.js';
+import { printBanner } from '../utils.js';
+
+interface SignUpResponse {
+  content?: string;
+}
+
+export async function signupCommand(args: string[]): Promise<void> {
+  printBanner();
+
+  const email = args[0];
+
+  if (!email) {
+    console.log('Usage: memori sign-up <email_address>\n');
+    process.exit(1);
+  }
+
+  const config = new Config();
+  const api = new Api(config);
+
+  try {
+    const response = await api.post<SignUpResponse>('sdk/account', { email });
+    console.log(response.content || "You're all set! We sent you an email.\n");
+  } catch (error) {
+    if (error instanceof MemoriApiValidationError) {
+      console.log(`The email you provided "${email}" is not valid.\n`);
+    } else {
+      console.error('An unexpected error occurred during sign-up.');
+      if (error instanceof Error) {
+        console.error(`Error details: ${error.message}\n`);
+      }
+      process.exit(1);
+    }
+  }
+}

--- a/memori-ts/src/cli/router.ts
+++ b/memori-ts/src/cli/router.ts
@@ -1,7 +1,9 @@
 import { quotaCommand } from './commands/quota.js';
 import { helpCommand } from './commands/help.js';
+import { signupCommand } from './commands/signup.js';
 
 const commands: Record<string, ((args: string[]) => Promise<void>) | undefined> = {
+  'sign-up': signupCommand,
   quota: quotaCommand,
   help: helpCommand,
 };

--- a/memori-ts/tests/cli/bin/router.test.ts
+++ b/memori-ts/tests/cli/bin/router.test.ts
@@ -2,12 +2,16 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { main } from '../../../src/cli/router.js';
 import { quotaCommand } from '../../../src/cli/commands/quota.js';
 import { helpCommand } from '../../../src/cli/commands/help.js';
+import { signupCommand } from '../../../src/cli/commands/signup.js';
 
 vi.mock('../../../src/cli/commands/quota.js', () => ({
   quotaCommand: vi.fn(),
 }));
 vi.mock('../../../src/cli/commands/help.js', () => ({
   helpCommand: vi.fn(),
+}));
+vi.mock('../../../src/cli/commands/signup.js', () => ({
+  signupCommand: vi.fn(),
 }));
 
 describe('CLI Router', () => {
@@ -34,6 +38,13 @@ describe('CLI Router', () => {
     await main();
 
     expect(quotaCommand).toHaveBeenCalledWith([]);
+  });
+
+  it('should route to the sign-up command and pass arguments successfully', async () => {
+    process.argv = ['node', 'cli.js', 'sign-up', 'test@example.com'];
+    await main();
+
+    expect(signupCommand).toHaveBeenCalledWith(['test@example.com']);
   });
 
   it('should route to the help command when no arguments are provided', async () => {

--- a/memori-ts/tests/cli/commands/signup.test.ts
+++ b/memori-ts/tests/cli/commands/signup.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { signupCommand } from '../../../src/cli/commands/signup.js';
+import * as utils from '../../../src/cli/utils.js';
+import { MemoriApiValidationError } from '../../../src/core/errors.js';
+
+vi.mock('../../../src/cli/utils.js', () => ({
+  printBanner: vi.fn(),
+}));
+
+const mockPost = vi.fn();
+
+vi.mock('../../../src/core/network.js', () => {
+  return {
+    Api: class MockApi {
+      post = mockPost;
+    },
+  };
+});
+
+describe('signupCommand', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    processExitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit called with code: ${code}`);
+    }) as any) as any;
+
+    mockPost.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should print usage and exit if no email is provided', async () => {
+    // Expect the command to reject with our mock exit error
+    await expect(signupCommand([])).rejects.toThrow('process.exit called with code: 1');
+
+    expect(utils.printBanner).toHaveBeenCalled();
+    expect(consoleLogSpy).toHaveBeenCalledWith('Usage: memori sign-up <email_address>\n');
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('should post email and print returned content on success', async () => {
+    mockPost.mockResolvedValue({ content: 'Custom API success message!' });
+
+    await signupCommand(['test@example.com']);
+
+    expect(mockPost).toHaveBeenCalledWith('sdk/account', { email: 'test@example.com' });
+    expect(consoleLogSpy).toHaveBeenCalledWith('Custom API success message!');
+    expect(processExitSpy).not.toHaveBeenCalled();
+  });
+
+  it('should post email and print fallback content on success if none is returned', async () => {
+    mockPost.mockResolvedValue({}); // No content field
+
+    await signupCommand(['test@example.com']);
+
+    expect(consoleLogSpy).toHaveBeenCalledWith("You're all set! We sent you an email.\n");
+    expect(processExitSpy).not.toHaveBeenCalled();
+  });
+
+  it('should gracefully handle validation errors and inform the user', async () => {
+    mockPost.mockRejectedValue(new MemoriApiValidationError(422, 'Email is invalid format'));
+
+    await signupCommand(['bad-email']);
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      'The email you provided "bad-email" is not valid.\n'
+    );
+    expect(processExitSpy).not.toHaveBeenCalled();
+  });
+
+  it('should print error and exit with code 1 on unexpected API failure', async () => {
+    mockPost.mockRejectedValue(new Error('Network timeout'));
+
+    // Expect the command to reject with our mock exit error
+    await expect(signupCommand(['test@example.com'])).rejects.toThrow(
+      'process.exit called with code: 1'
+    );
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('An unexpected error occurred during sign-up.');
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error details: Network timeout\n');
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+});


### PR DESCRIPTION
- Introduce a new sign-up CLI command that prints the banner, validates presence of an email arg, calls the API (sdk/account), and handles validation and unexpected errors. 
- Update CLI router to register the "sign-up" command. 
- Add unit tests: router test covers routing to sign-up; signup tests cover usage/help exit, successful responses (with custom content and fallback message), validation error handling, and unexpected API failures with proper logging and exit behavior. -bump version number