### PR TITLE
Add memori signup & quota tools to OC

### DIFF
--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -141,9 +141,11 @@ Status: Ready
 ### 4. Test the memory loop
 
 1. Tell the agent something durable:
+
    > "I always use TypeScript and prefer functional patterns."
 
 2. Start a new session and ask:
+
    > "Write a hello world script in my preferred language."
 
 3. Confirm the agent used `memori_recall` to fetch your preferences:

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -25,7 +25,7 @@
 
 ---
 
-# OpenClaw Overview
+# Memori for OpenClaw
 
 Memori gives OpenClaw agents a structured, long-term memory system. It automatically captures what happens and lets agents recall it on demand — so context survives across sessions without bloating the prompt.
 
@@ -33,79 +33,38 @@ Instead of relying solely on natural-language memory, Memori structures persiste
 
 ---
 
-## The Problem with OpenClaw's Built-In Memory
+## The problem
 
-OpenClaw ships with a basic memory layer, but it has fundamental limitations that break down at scale:
+OpenClaw's default memory works for simple use cases, but breaks at scale:
 
-| Limitation                    | What happens                                                                                                                                                            |
-| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Flat markdown files**       | Memory lives in plain text files with no structure or relationships. The agent reads and writes large chunks of text with no way to index, query, or deduplicate facts. |
-| **Context compaction**        | As sessions grow longer, important details begin to disappear. Memory gets lost when context is compressed to stay within token limits.                                 |
-| **No relationship reasoning** | OpenClaw retrieves semantically similar text, but cannot understand relationships between facts or connect them to each other.                                          |
-| **Weak daily briefs**         | Daily summaries are shallow and lossy, missing key decisions, constraints, and patterns from prior sessions.                                                            |
-| **Cross-project noise**       | When working across multiple projects, memories are not isolated. Searches return irrelevant results from other contexts, polluting the agent's responses.              |
-| **No user isolation**         | Users do not have their own isolated memories. Memories bleed across users and data is mixed, creating privacy and relevance issues.                                    |
+- Memory is stored as flat markdown files
+- Context is lost due to compaction
+- Important decisions and constraints disappear
+- No relationships between facts
+- Memory bleeds across users and projects
 
 ---
 
-## What Changes When You Add Memori?
+## What Memori changes
 
-The Memori plugin replaces OpenClaw’s flat-file memory workflow with structured, scoped memory.
+Memori replaces flat memory with structured, scoped memory built from:
 
-### Memory scoping model
+- Agent execution (tool calls, results, decisions, outcomes)
 
-Memories are organized using four core identifiers:
-
-- **Project (`project_id`)** → The broader domain (e.g., “sales prospecting”)
-- **Process (`process_id`)** → The agent itself (e.g., “bob_the_sales_prospector”)
-- **Session (`session_id`)** → A specific run (e.g., “prospecting_2026-04-29”)
-- **Entity (`entity_id`)** → The subject of memory (e.g., the user, customer, or system being tracked)
-
-> Note: If a `session_id` is provided, a `project_id` must also be provided.  
-> All timestamps are stored in **UTC**.
+Instead of replaying history, agents retrieve exactly what they need.
 
 ---
 
-## Core Capabilities
+## How it works
 
-### 1. Structured memory from conversation and agent trace
+Memori runs on two parallel systems:
 
-Memori transforms raw agent sessions (messages + traces) into structured memory primitives and continuously updated summaries.
-
-Instead of replaying full transcripts, Memori turns conversation and agent execution into structured memory that preserves what the agent did, what happened, and what it learned across long-running interactions.
-
-The system focuses on extracting what matters:
-
-- Key facts
-- Decisions
-- Outcomes
-- Patterns
-
-Rather than preserving every detail, Memori prioritizes signal over noise — keeping context lean while retaining meaning. This avoids replaying or summarizing entire conversations on every turn.
-
-#### Dual memory model
-
-Memori stores knowledge in two complementary forms:
-
-- **Structured memory primitives** — precise, queryable records of facts, decisions, constraints, actions, tool results, and outcomes used for targeted retrieval and reasoning
-- **Rolling summaries** — continuously updated context used for grounding and situational awareness
-
-Structured memory is stored in a knowledge graph, enabling relationships, deduplication, and precise retrieval.
-
-#### Grounded in agent execution, not just text
-
-Memori incorporates tool calls and execution traces alongside conversation data. This means memory reflects not just what was discussed, but what the agent actually did and what results those actions produced.
-
-By structuring memory from actions, tool results, decisions, and outcomes, the system gives the agent a fuller understanding of prior task execution so the next time it acts, it can be more accurate and efficient.
-
----
-
-### 2. Advanced Augmentation (automatic)
+### 1. Advanced augmentation
 
 After each interaction, Memori converts raw session data into structured, reusable memories asynchronously.
 
 - Transforms raw agent sessions into structured memory units
-- Captures the agent’s actions, reasoning, tool usage, responses, corrections, and failures
+- Captures the agent's actions, reasoning, tool usage, responses, corrections, and failures
 - Organizes into classes to enable efficient retrieval
 - Generates embeddings for semantic retrieval
 - Updates structured memory and the knowledge graph
@@ -116,7 +75,7 @@ It runs **after the agent responds** and does not impact latency.
 
 ---
 
-### 3. Agent-controlled recall
+### 2. Agent-controlled recall
 
 Recall is **explicit and initiated by the agent**.
 
@@ -131,208 +90,33 @@ Agents decide:
 - What scope to recall from
 - How much history to include
 
-Supported parameters:
-
-- `entity_id`
-- `project_id`
-- `session_id`
-- `date_start`
-- `date_end`
-- `source`
-- `signal`
-
-#### Memory classification schema
-
-**Sources**
-
-- constraint
-- decision
-- execution
-- fact
-- insight
-- instruction
-- status
-- strategy
-- task
-
-**Signals**
-
-- commit
-- discovery
-- failure
-- inference
-- pattern
-- result
-- update
-- verification
-
-#### Default behavior
-
-- If no date range is provided → returns **all-time**
-
-#### Returned context may include:
-
-- Relevant facts
-- Prior decisions
-- Constraints
-- Patterns
-- Summaries
-
----
-
-### 4. Summaries and daily briefs
-
-Memori provides structured summaries that go beyond OpenClaw’s default daily brief.
-
-These summaries are generated from structured memory and execution traces — not just compressed conversation history.
-
-They represent the agent’s **working state**, not just a recap.
-
-#### Daily brief structure
-
-Memori generates a consistent, structured daily brief with the following sections:
-
-- **Today at a glance** — high-level summary of activity and progress
-- **Top 3 next actions** — highest priority tasks
-- **Top 3 risks** — immediate risks or blockers
-- **Verify before acting** — assumptions requiring validation
-- **Recent decisions** — key decisions and context
-- **Mission stack** — active goals and objectives
-- **Hard constraints** — non-negotiable rules
-- **Current status** — current state of execution
-- **Open loops** — unresolved tasks or dependencies
-- **Known failures and anti-patterns** — what to avoid
-- **Staleness warnings** — potentially outdated information
-
-This structure ensures the daily brief is:
-
-- Actionable
-- Reliable
-- Context-aware
-
-Supported parameters:
-
-- `project_id`
-- `session_id`
-- `date_start`
-- `date_end`
-
-#### Default behavior
-
-- If no date range is provided → returns **last 24 hours**
-
----
-
-### 5. Production-ready observability
-
-Memori Cloud provides full visibility into memory behavior:
-
-- Memory creation and updates
-- Recall activity and hit rates
-- Session tracking
-- Quota usage
-- Top entities and subjects
-- Retrieval performance metrics
-
----
-
-## How it Works
-
-Memori separates memory into two systems:
-
-- **Advanced Augmentation (automatic)** — captures and structures memory
-- **Agent-controlled recall (on demand)** — retrieves memory when needed
-
-### 1. Advanced Augmentation (`agent_end` hook)
-
-1. Extract the latest user and assistant messages
-2. Sanitize the exchange (remove metadata, timestamps, thinking blocks)
-3. Send asynchronously to Memori
-4. Memori:
-   - Extracts durable facts
-   - Deduplicates and updates memory
-   - Updates structured memory and the knowledge graph
-
-This runs in the background and **never blocks the agent’s response**.
-
----
-
-### 2. Agent-controlled recall (plugin tools)
-
-Memori does not automatically inject memory. The agent retrieves it explicitly.
+Memori does not automatically inject memory into the prompt. The agent retrieves only the context it needs, keeping token usage efficient.
 
 Available tools:
 
-- **`memori_recall`**  
-  Query structured memory for facts, constraints, decisions, and patterns
-
-- **`memori_recall_summary`**  
-  Retrieve summaries and the daily brief
-
-- **`memori_feedback`**  
-  Report on memory quality to improve the system
+- **`memori_recall`** — query structured memory for facts, constraints, decisions, and patterns
+- **`memori_recall_summary`** — retrieve summaries and the daily brief
+- **`memori_feedback`** — report on memory quality to improve the system
 
 ---
 
-### 3. Retrieval model
+## Quickstart
 
-Memori returns:
-
-- High-signal structured memory
-- Rolling summaries and daily briefs
-- Context scoped by entity, project, session, and time
-
-This keeps context:
-
-- **Targeted**
-- **Compact**
-- **Actionable**
-
-## Memori and Agent Interaction
-
-Memori provides agents with a set of tools to interact with memory in real time.
-
-- **Feedback (`memori_feedback`)**  
-  Agents can send feedback to improve memory quality, including missing context or incorrect recall.
-
-- **Updates**  
-  Memori evolves over time. Agents can detect new capabilities and adapt their behavior accordingly.
-
-- **Quota awareness**  
-  Memori enforces usage limits. When limits are reached, agents can adjust recall behavior and inform the user if needed.
-
-These interactions make Memori a two-way system: agents don’t just retrieve memory — they help improve and shape it over time.
-
-See SKILL.md for detailed agent behavior.
-
----
-
-# OpenClaw Quickstart
-
-Get a structured, long-term memory system running in your OpenClaw gateway in three steps.
-
-## Prerequisites
+### Prerequisites
 
 - [OpenClaw](https://openclaw.ai) `v2026.3.2` or later
 - A Memori API key from [app.memorilabs.ai](https://app.memorilabs.ai)
 - An Entity ID to scope memory to a specific user, agent, or system
 - A Project ID to scope memory to a specific project or workspace
 
-## 1. Install and Enable
+### 1. Install
 
 ```bash
-# Install the plugin from npm
 openclaw plugins install @memorilabs/openclaw-memori
-
-# Enable it in your workspace
 openclaw plugins enable openclaw-memori
 ```
 
-## 2. Configure
-
-You need three values: your Memori API key, an Entity ID, and a Project ID.
-
-### Option A: Via CLI (Recommended)
+### 2. Configure
 
 ```bash
 openclaw memori init \
@@ -341,106 +125,77 @@ openclaw memori init \
   --project-id "my-project"
 ```
 
-### Option B: Via `openclaw.json`
-
-Add the following to `~/.openclaw/openclaw.json`:
-
-```json
-{
-  "plugins": {
-    "entries": {
-      "openclaw-memori": {
-        "enabled": true,
-        "config": {
-          "apiKey": "your-memori-api-key",
-          "entityId": "your-app-user-id",
-          "projectId": "my-project"
-        }
-      }
-    }
-  }
-}
-```
-
-### Configuration Options
-
-<Properties>
-  <Property name="apiKey" type="string" required>
-    Your Memori API key, available from [app.memorilabs.ai](https://app.memorilabs.ai).
-  </Property>
-  <Property name="entityId" type="string" required>
-    A unique identifier for the entity (user, agent, or tenant) to attribute memories to.
-  </Property>
-  <Property name="projectId" type="string" required>
-    A project or workspace ID used to scope all extracted facts and summaries.
-  </Property>
-</Properties>
-
-## 3. Verify
-
-After configuring, restart the gateway and verify your API connectivity:
+### 3. Verify
 
 ```bash
 openclaw gateway restart
 openclaw memori status --check
 ```
 
-You should see:
+Expected:
 
 ```
-Memori Plugin Status
-────────────────────────────────────
-  API Key:    ****...A3xQ
-  Entity ID:  your-app-user-id
-  Project ID: my-project
-
-Checking API connectivity... OK
 Status: Ready
 ```
 
-### Test the Full Memory Loop
+### 4. Test the memory loop
 
-1. Send a message with a durable preference:
-
+1. Tell the agent something durable:
    > "I always use TypeScript and prefer functional patterns."
 
-2. Check the gateway logs to confirm advanced augmentation ran in the background:
-
-   ```
-   [Memori] Augmentation successful!
-   ```
-
-3. Start a new session (so the agent is a blank slate) and ask:
-
+2. Start a new session and ask:
    > "Write a hello world script in my preferred language."
 
-4. Confirm the agent used `memori_recall` to fetch your preferences:
-
+3. Confirm the agent used `memori_recall` to fetch your preferences:
    ```
    [Memori] memori_recall params: {"projectId":"my-project","query":"preferred programming language"}
    ```
 
-5. Tell the agent to send feedback:
-   > "Send feedback to the developers that the recall was perfect." (This will trigger the `memori_feedback` tool).
+If it works, you now have persistent memory across sessions.
 
 ---
 
-## What Happens Under the Hood
+## Memory model
 
-The Memori plugin operates on two parallel tracks:
+Memory is scoped to prevent noise and ensure relevance:
 
-| Track                       | Mechanism        | What it does                                                                                                                                                                                 |
-| --------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Agent-Controlled Recall** | Plugin Tools     | Equips the agent with `memori_recall`, `memori_recall_summary`, and `memori_feedback`. The agent retrieves memory explicitly when needed.                                                    |
-| **Advanced Augmentation**   | `agent_end` Hook | After the agent responds, the exchange and execution trace are sanitized and sent to Memori in the background to structure memory from conversation, tool activity, decisions, and outcomes. |
+- `entity_id` → user, agent, or system context
+- `project_id` → project or workspace context
+- `session_id` → specific session (requires `project_id`)
+- `date_start` / `date_end` → time-bounded recall (defaults to all-time if omitted)
+- `source` → type of memory (recall only)
+- `signal` → how the memory was derived (recall only)
 
-Together, these systems continuously structure memory from not just natural language, but also from agent trace and execution. Memori captures the agent's actions, tool results, decisions, and outcomes into durable memory the agent can recall on demand — so the next time it performs a task, it is more accurate and efficient.
+All timestamps are stored in **UTC**.
 
-Memori does not automatically inject memory into the prompt. Instead, agents retrieve only the context they need, improving accuracy and efficiency while avoiding unnecessary token usage.
+---
 
-<Admonition type="tip" title="Multi-Agent Gateways">
-  The plugin is fully stateless and thread-safe. You can run it across multiple agents in the same gateway without any shared state or concurrency issues.
-</Admonition>
+## Agent behavior (read this)
+
+Agents should:
+
+- Retrieve a summary at the start of meaningful sessions
+- Use targeted recall (not broad queries)
+- Avoid recalling on every turn
+- Use memory only when context is needed
+- Send feedback when memory is missing or incorrect
+
+See SKILL.md for full behavior guidelines.
+
+---
+
+## Typical workflow
+
+1. Start session → retrieve summary
+2. During task → targeted recall
+3. Missing context → send feedback
+4. End of session → memory is captured automatically
+
+---
+
+## Multi-agent ready
+
+The plugin is fully stateless and thread-safe. You can run it across multiple agents in the same gateway without shared state or concurrency issues.
 
 ---
 

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -25,69 +25,300 @@
 
 ---
 
-## Why Memori for OpenClaw?
+# OpenClaw Overview
 
-OpenClaw ships with a simple file-first memory system designed for lightweight experimentation. As deployments scale into production environments, teams often run into memory problems that need more structured, deterministic infrastructure.
+Memori gives OpenClaw agents a structured, long-term memory system. It automatically captures what happens and lets agents recall it on demand — so context survives across sessions without bloating the prompt.
 
-Memori provides a drop-in memory layer purpose-built for agentic systems running OpenClaw in production. It works through OpenClaw's plugin lifecycle, so you get persistent, structured memory without changing your agent logic.
+Instead of relying solely on natural-language memory, Memori structures persistent memory from both conversation and agent trace — the agent's actions, tool results, decisions, and outcomes — so it can recall what actually happened when it matters.
 
-## Common Challenges with Default OpenClaw Memory
+---
 
-### 1. Fact conflicts in long-running agents
+## The Problem with OpenClaw's Built-In Memory
 
-OpenClaw stores memory as plain markdown files. When facts change or contradict over time, there is no deterministic conflict resolution or lifecycle management.
+OpenClaw ships with a basic memory layer, but it has fundamental limitations that break down at scale:
 
-Memori introduces structured memory with update logic, decay policies, and deterministic fact handling.
+| Limitation                    | What happens                                                                                                                                                            |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Flat markdown files**       | Memory lives in plain text files with no structure or relationships. The agent reads and writes large chunks of text with no way to index, query, or deduplicate facts. |
+| **Context compaction**        | As sessions grow longer, important details begin to disappear. Memory gets lost when context is compressed to stay within token limits.                                 |
+| **No relationship reasoning** | OpenClaw retrieves semantically similar text, but cannot understand relationships between facts or connect them to each other.                                          |
+| **Weak daily briefs**         | Daily summaries are shallow and lossy, missing key decisions, constraints, and patterns from prior sessions.                                                            |
+| **Cross-project noise**       | When working across multiple projects, memories are not isolated. Searches return irrelevant results from other contexts, polluting the agent's responses.              |
+| **No user isolation**         | Users do not have their own isolated memories. Memories bleed across users and data is mixed, creating privacy and relevance issues.                                    |
 
-### 2. Context loss from token limits
-
-As sessions grow, context must be compacted to fit within model token limits. Important details can be dropped during compression.
-
-Memori stores memory outside the prompt and retrieves the right facts at query time, eliminating compaction loss.
-
-### 3. No relationship reasoning
-
-OpenClaw retrieves semantically similar text but does not model relationships between entities.
-
-Memori builds structured memory graphs that let agents reason across linked facts, not just retrieve similar chunks.
-
-### 4. Cross-project noise
-
-When multiple projects share memory storage, irrelevant context can bleed across workflows.
-
-Memori supports scoped memory namespaces to isolate projects and workflows.
-
-### 5. No user-level isolation
-
-Default memory systems do not provide deterministic isolation across users.
-
-Memori enforces user-scoped memory boundaries for secure multi-user deployments.
+---
 
 ## What Changes When You Add Memori?
 
-The Memori plugin replaces OpenClaw's flat-file memory workflow with managed, structured memory that is scoped by `entity_id`, `process_id`, and `session_id` and enriched automatically through OpenClaw's existing hooks.
+The Memori plugin replaces OpenClaw’s flat-file memory workflow with structured, scoped memory.
 
-| Capability                         | What changes                                                                                                                                                                                                                                                                                                                                                           |
-| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Structured memory storage**      | Instead of raw markdown blobs, Memori stores conversations, facts, preferences, and knowledge-graph triples as structured records tied to an entity, process, and session. Facts are extracted as subject-predicate-object relationships, deduplicated over time, and connected into a graph so related memories stay queryable instead of being buried in text files. |
-| **Advanced Augmentation**          | After each conversation, Memori processes the user and assistant exchange asynchronously in the background, identifies facts, preferences, skills, and attributes, generates embeddings for semantic search, and updates the knowledge graph without blocking the agent's response path.                                                                               |
-| **Intelligent Recall**             | Before the agent responds, Memori searches the current entity's stored facts and knowledge graph, ranks memories by semantic relevance and importance, and injects the most useful context into the prompt so durable knowledge survives context-window compression.                                                                                                   |
-| **Production-ready observability** | Memori Cloud gives you dashboard visibility into memory creation, recalls, cache hit rate, sessions, quota usage, top subjects, per-memory retrieval metrics, and knowledge-graph relationships, so you can inspect what was stored and how recall is behaving in production.                                                                                          |
+### Memory scoping model
 
-The plugin still remains drop-in: OpenClaw handles the agent loop, while Memori adds recall, augmentation, sanitization, and observability around it.
+Memories are organized using four core identifiers:
 
-## Quickstart
+- **Project (`project_id`)** → The broader domain (e.g., “sales prospecting”)
+- **Process (`process_id`)** → The agent itself (e.g., “bob_the_sales_prospector”)
+- **Session (`session_id`)** → A specific run (e.g., “prospecting_2026-04-29”)
+- **Entity (`entity_id`)** → The subject of memory (e.g., the user, customer, or system being tracked)
 
-Get persistent memory running in your OpenClaw gateway in three steps.
+> Note: If a `session_id` is provided, a `project_id` must also be provided.  
+> All timestamps are stored in **UTC**.
 
-### Prerequisites
+---
+
+## Core Capabilities
+
+### 1. Structured memory from conversation and agent trace
+
+Memori transforms raw agent sessions (messages + traces) into structured memory primitives and continuously updated summaries.
+
+Instead of replaying full transcripts, Memori turns conversation and agent execution into structured memory that preserves what the agent did, what happened, and what it learned across long-running interactions.
+
+The system focuses on extracting what matters:
+
+- Key facts
+- Decisions
+- Outcomes
+- Patterns
+
+Rather than preserving every detail, Memori prioritizes signal over noise — keeping context lean while retaining meaning. This avoids replaying or summarizing entire conversations on every turn.
+
+#### Dual memory model
+
+Memori stores knowledge in two complementary forms:
+
+- **Structured memory primitives** — precise, queryable records of facts, decisions, constraints, actions, tool results, and outcomes used for targeted retrieval and reasoning
+- **Rolling summaries** — continuously updated context used for grounding and situational awareness
+
+Structured memory is stored in a knowledge graph, enabling relationships, deduplication, and precise retrieval.
+
+#### Grounded in agent execution, not just text
+
+Memori incorporates tool calls and execution traces alongside conversation data. This means memory reflects not just what was discussed, but what the agent actually did and what results those actions produced.
+
+By structuring memory from actions, tool results, decisions, and outcomes, the system gives the agent a fuller understanding of prior task execution so the next time it acts, it can be more accurate and efficient.
+
+---
+
+### 2. Advanced Augmentation (automatic)
+
+After each interaction, Memori converts raw session data into structured, reusable memories asynchronously.
+
+- Transforms raw agent sessions into structured memory units
+- Captures the agent’s actions, reasoning, tool usage, responses, corrections, and failures
+- Organizes into classes to enable efficient retrieval
+- Generates embeddings for semantic retrieval
+- Updates structured memory and the knowledge graph
+
+This is how structured memory is continuously built and updated over time.
+
+It runs **after the agent responds** and does not impact latency.
+
+---
+
+### 3. Agent-controlled recall
+
+Recall is **explicit and initiated by the agent**.
+
+Memori separates memory creation from memory recall:
+
+- Creation is automatic (advanced augmentation)
+- Recall is intentional (agent-controlled)
+
+Agents decide:
+
+- When to recall
+- What scope to recall from
+- How much history to include
+
+Supported parameters:
+
+- `entity_id`
+- `project_id`
+- `session_id`
+- `date_start`
+- `date_end`
+- `source`
+- `signal`
+
+#### Memory classification schema
+
+**Sources**
+
+- constraint
+- decision
+- execution
+- fact
+- insight
+- instruction
+- status
+- strategy
+- task
+
+**Signals**
+
+- commit
+- discovery
+- failure
+- inference
+- pattern
+- result
+- update
+- verification
+
+#### Default behavior
+
+- If no date range is provided → returns **all-time**
+
+#### Returned context may include:
+
+- Relevant facts
+- Prior decisions
+- Constraints
+- Patterns
+- Summaries
+
+---
+
+### 4. Summaries and daily briefs
+
+Memori provides structured summaries that go beyond OpenClaw’s default daily brief.
+
+These summaries are generated from structured memory and execution traces — not just compressed conversation history.
+
+They represent the agent’s **working state**, not just a recap.
+
+#### Daily brief structure
+
+Memori generates a consistent, structured daily brief with the following sections:
+
+- **Today at a glance** — high-level summary of activity and progress
+- **Top 3 next actions** — highest priority tasks
+- **Top 3 risks** — immediate risks or blockers
+- **Verify before acting** — assumptions requiring validation
+- **Recent decisions** — key decisions and context
+- **Mission stack** — active goals and objectives
+- **Hard constraints** — non-negotiable rules
+- **Current status** — current state of execution
+- **Open loops** — unresolved tasks or dependencies
+- **Known failures and anti-patterns** — what to avoid
+- **Staleness warnings** — potentially outdated information
+
+This structure ensures the daily brief is:
+
+- Actionable
+- Reliable
+- Context-aware
+
+Supported parameters:
+
+- `project_id`
+- `session_id`
+- `date_start`
+- `date_end`
+
+#### Default behavior
+
+- If no date range is provided → returns **last 24 hours**
+
+---
+
+### 5. Production-ready observability
+
+Memori Cloud provides full visibility into memory behavior:
+
+- Memory creation and updates
+- Recall activity and hit rates
+- Session tracking
+- Quota usage
+- Top entities and subjects
+- Retrieval performance metrics
+
+---
+
+## How it Works
+
+Memori separates memory into two systems:
+
+- **Advanced Augmentation (automatic)** — captures and structures memory
+- **Agent-controlled recall (on demand)** — retrieves memory when needed
+
+### 1. Advanced Augmentation (`agent_end` hook)
+
+1. Extract the latest user and assistant messages
+2. Sanitize the exchange (remove metadata, timestamps, thinking blocks)
+3. Send asynchronously to Memori
+4. Memori:
+   - Extracts durable facts
+   - Deduplicates and updates memory
+   - Updates structured memory and the knowledge graph
+
+This runs in the background and **never blocks the agent’s response**.
+
+---
+
+### 2. Agent-controlled recall (plugin tools)
+
+Memori does not automatically inject memory. The agent retrieves it explicitly.
+
+Available tools:
+
+- **`memori_recall`**  
+  Query structured memory for facts, constraints, decisions, and patterns
+
+- **`memori_recall_summary`**  
+  Retrieve summaries and the daily brief
+
+- **`memori_feedback`**  
+  Report on memory quality to improve the system
+
+---
+
+### 3. Retrieval model
+
+Memori returns:
+
+- High-signal structured memory
+- Rolling summaries and daily briefs
+- Context scoped by entity, project, session, and time
+
+This keeps context:
+
+- **Targeted**
+- **Compact**
+- **Actionable**
+
+## Memori and Agent Interaction
+
+Memori provides agents with a set of tools to interact with memory in real time.
+
+- **Feedback (`memori_feedback`)**  
+  Agents can send feedback to improve memory quality, including missing context or incorrect recall.
+
+- **Updates**  
+  Memori evolves over time. Agents can detect new capabilities and adapt their behavior accordingly.
+
+- **Quota awareness**  
+  Memori enforces usage limits. When limits are reached, agents can adjust recall behavior and inform the user if needed.
+
+These interactions make Memori a two-way system: agents don’t just retrieve memory — they help improve and shape it over time.
+
+See SKILL.md for detailed agent behavior.
+
+---
+
+# OpenClaw Quickstart
+
+Get a structured, long-term memory system running in your OpenClaw gateway in three steps.
+
+## Prerequisites
 
 - [OpenClaw](https://openclaw.ai) `v2026.3.2` or later
 - A Memori API key from [app.memorilabs.ai](https://app.memorilabs.ai)
-- An Entity ID to attribute memories to, such as a user ID, tenant ID, or agent name
-- A Project ID to scope memories to a specific project or workspace
+- An Entity ID to scope memory to a specific user, agent, or system
+- A Project ID to scope memory to a specific project or workspace
 
-### 1. Install and Enable
+## 1. Install and Enable
 
 ```bash
 # Install the plugin from npm
@@ -97,35 +328,22 @@ openclaw plugins install @memorilabs/openclaw-memori
 openclaw plugins enable openclaw-memori
 ```
 
-### 2. Configure
+## 2. Configure
 
-The plugin requires an API key, an Entity ID, and a Project ID. Use the built-in `memori` CLI to configure it in one step.
+You need three values: your Memori API key, an Entity ID, and a Project ID.
 
-#### Option A: Memori CLI (Recommended)
+### Option A: Via CLI (Recommended)
 
 ```bash
 openclaw memori init \
   --api-key "YOUR_MEMORI_API_KEY" \
-  --entity-id "your-entity-id" \
-  --project-id "your-project-id"
+  --entity-id "your-app-user-id" \
+  --project-id "my-project"
 ```
 
-Then restart the gateway:
+### Option B: Via `openclaw.json`
 
-```bash
-openclaw gateway restart
-```
-
-#### Option B: OpenClaw config set
-
-```bash
-openclaw config set plugins.entries.openclaw-memori.config.apiKey "YOUR_MEMORI_API_KEY"
-openclaw config set plugins.entries.openclaw-memori.config.entityId "your-entity-id"
-openclaw config set plugins.entries.openclaw-memori.config.projectId "your-project-id"
-openclaw gateway restart
-```
-
-#### Option C: Direct JSON (`~/.openclaw/openclaw.json`)
+Add the following to `~/.openclaw/openclaw.json`:
 
 ```json
 {
@@ -135,8 +353,8 @@ openclaw gateway restart
         "enabled": true,
         "config": {
           "apiKey": "your-memori-api-key",
-          "entityId": "your-entity-id",
-          "projectId": "your-project-id"
+          "entityId": "your-app-user-id",
+          "projectId": "my-project"
         }
       }
     }
@@ -146,108 +364,85 @@ openclaw gateway restart
 
 ### Configuration Options
 
-| Option      | Type     | Required | Description                                                                                         |
-| ----------- | -------- | -------- | --------------------------------------------------------------------------------------------------- |
-| `apiKey`    | `string` | **Yes**  | Your Memori API key from [app.memorilabs.ai](https://app.memorilabs.ai).                            |
-| `entityId`  | `string` | **Yes**  | The unique identifier for the entity (e.g., user, agent, or tenant) to attribute these memories to. |
-| `projectId` | `string` | **Yes**  | Scopes all memories to a specific project or workspace.                                             |
+<Properties>
+  <Property name="apiKey" type="string" required>
+    Your Memori API key, available from [app.memorilabs.ai](https://app.memorilabs.ai).
+  </Property>
+  <Property name="entityId" type="string" required>
+    A unique identifier for the entity (user, agent, or tenant) to attribute memories to.
+  </Property>
+  <Property name="projectId" type="string" required>
+    A project or workspace ID used to scope all extracted facts and summaries.
+  </Property>
+</Properties>
 
-### 3. Verify
+## 3. Verify
 
-Check that the plugin is configured and can reach the API:
+After configuring, restart the gateway and verify your API connectivity:
 
 ```bash
+openclaw gateway restart
 openclaw memori status --check
 ```
 
 You should see:
 
-```text
+```
 Memori Plugin Status
 ────────────────────────────────────
   API Key:    ****...A3xQ
-  Entity ID:  your-entity-id
-  Project ID: your-project-id
+  Entity ID:  your-app-user-id
+  Project ID: my-project
 
 Checking API connectivity... OK
 Status: Ready
 ```
 
-You can also inspect gateway logs to confirm the plugin loaded:
-
-```bash
-openclaw gateway logs --filter "[Memori]"
-```
-
-```text
-[Memori] === INITIALIZING PLUGIN ===
-[Memori] Tracking Entity ID: your-entity-id
-```
-
-To test the full memory loop:
+### Test the Full Memory Loop
 
 1. Send a message with a durable preference:
-   `I always use TypeScript and prefer functional patterns.`
-2. Confirm augmentation ran:
-   `Augmentation successful!`
-3. Start a new session and ask:
-   `Write a hello world script.`
-4. Confirm recall ran:
-   `Successfully injected memory context.`
+
+   > "I always use TypeScript and prefer functional patterns."
+
+2. Check the gateway logs to confirm advanced augmentation ran in the background:
+
+   ```
+   [Memori] Augmentation successful!
+   ```
+
+3. Start a new session (so the agent is a blank slate) and ask:
+
+   > "Write a hello world script in my preferred language."
+
+4. Confirm the agent used `memori_recall` to fetch your preferences:
+
+   ```
+   [Memori] memori_recall params: {"projectId":"my-project","query":"preferred programming language"}
+   ```
+
+5. Tell the agent to send feedback:
+   > "Send feedback to the developers that the recall was perfect." (This will trigger the `memori_feedback` tool).
 
 ---
 
-## CLI Reference
+## What Happens Under the Hood
 
-The plugin registers a `memori` command group in the OpenClaw CLI.
+The Memori plugin operates on two parallel tracks:
 
-### `openclaw memori init`
+| Track                       | Mechanism        | What it does                                                                                                                                                                                 |
+| --------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Agent-Controlled Recall** | Plugin Tools     | Equips the agent with `memori_recall`, `memori_recall_summary`, and `memori_feedback`. The agent retrieves memory explicitly when needed.                                                    |
+| **Advanced Augmentation**   | `agent_end` Hook | After the agent responds, the exchange and execution trace are sanitized and sent to Memori in the background to structure memory from conversation, tool activity, decisions, and outcomes. |
 
-Configure the plugin with your credentials. All three flags are required.
+Together, these systems continuously structure memory from not just natural language, but also from agent trace and execution. Memori captures the agent's actions, tool results, decisions, and outcomes into durable memory the agent can recall on demand — so the next time it performs a task, it is more accurate and efficient.
 
-```bash
-openclaw memori init \
-  --api-key <key> \
-  --entity-id <id> \
-  --project-id <id>
-```
+Memori does not automatically inject memory into the prompt. Instead, agents retrieve only the context they need, improving accuracy and efficiency while avoiding unnecessary token usage.
 
-### `openclaw memori status`
+<Admonition type="tip" title="Multi-Agent Gateways">
+  The plugin is fully stateless and thread-safe. You can run it across multiple agents in the same gateway without any shared state or concurrency issues.
+</Admonition>
 
-Show the current configuration and whether the plugin is ready to run. Add `--check` to test live API connectivity.
-
-```bash
-openclaw memori status
-openclaw memori status --check
-```
-
-### `openclaw memori config`
-
-Fine-grained configuration management.
-
-```bash
-# Show all current values
-openclaw memori config show
-
-# Get a single value (API key is masked)
-openclaw memori config get api-key
-openclaw memori config get entity-id
-openclaw memori config get project-id
-
-# Set a single value
-openclaw memori config set api-key "NEW_KEY"
-openclaw memori config set entity-id "new-entity"
-openclaw memori config set project-id "new-project"
-```
-
-Valid keys: `api-key`, `entity-id`, `project-id`.
-
-## How It Works
-
-This plugin integrates with OpenClaw's event lifecycle to provide persistent memory without interfering with the agent's core logic:
-
-1. **`before_prompt_build` (Intelligent Recall):** When a user sends a message, the plugin intercepts the event, queries the Memori API, and safely prepends relevant memories to the agent's system context.
-2. **`agent_end` (Advanced Augmentation):** Once the agent finishes generating its response, the plugin captures the final `user` and `assistant` messages, sanitizes them, and sends them to the Memori integration endpoint for long-term storage and entity mapping.
+---
 
 ## Contributing
 

--- a/integrations/openclaw/openclaw.plugin.json
+++ b/integrations/openclaw/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-memori",
   "name": "Memori System",
-  "version": "0.0.8",
+  "version": "0.0.10",
   "description": "Hosted memory backend",
   "kind": "memory",
   "main": "dist/index.js",

--- a/integrations/openclaw/package-lock.json
+++ b/integrations/openclaw/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@memorilabs/openclaw-memori",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorilabs/openclaw-memori",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "license": "Apache-2.0",
       "dependencies": {
-        "@memorilabs/memori": "0.1.11-beta"
+        "@memorilabs/memori": "0.1.12-beta"
       },
       "devDependencies": {
         "@eslint/js": "^9.0.0",
@@ -31,9 +31,9 @@
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.20.0.tgz",
-      "integrity": "sha512-BxEHyE4MvwyOsdyVPub1vEtyrq8E0JSdjC+ckXWimY1VabFCTXdPyXv2y2Omz1j+iod7Z8oBJDXFCJptM0GBqQ==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.21.0.tgz",
+      "integrity": "sha512-ONj+Q8qOdNQp5XbH5jnMwzT9IKZJsSN0p0lkceS4GtUtNOPVLpNzSS8gqQdGMKfBvA0ESbkL8BTaSN1Rc9miEw==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
@@ -212,9 +212,9 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.1039.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1039.0.tgz",
-      "integrity": "sha512-rpm9rGcv95ulprNIu/ruhreG4bSKq7oFrErM1Nkp9Cq/zzo/11Hw1/ffYKLM/PAcMGZ+5/zAHOCWBDQ3W1lIBw==",
+      "version": "3.1040.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1040.0.tgz",
+      "integrity": "sha512-tFCqtci1gVGIRwgK3tmv2DV2EawXjBIQgwM/7KaeL4wHUMhNMUA+POUw6vGowtQb51ZaSDjK3KzI3MaQskOyuw==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -230,7 +230,7 @@
         "@aws-sdk/middleware-user-agent": "^3.972.37",
         "@aws-sdk/middleware-websocket": "^3.972.16",
         "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/token-providers": "3.1039.0",
+        "@aws-sdk/token-providers": "3.1040.0",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
@@ -433,6 +433,25 @@
         "@aws-sdk/core": "^3.974.7",
         "@aws-sdk/nested-clients": "^3.997.5",
         "@aws-sdk/token-providers": "3.1039.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1039.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1039.0.tgz",
+      "integrity": "sha512-NMSFL2HwkAOoCeLCQiqoOq5pT3vVbSjww2QZTuYgYknVwhhv125PSDzZIcL5EYnlxuPWjEOdauZK+FspkZDVdw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.7",
+        "@aws-sdk/nested-clients": "^3.997.5",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -699,9 +718,9 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1039.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1039.0.tgz",
-      "integrity": "sha512-NMSFL2HwkAOoCeLCQiqoOq5pT3vVbSjww2QZTuYgYknVwhhv125PSDzZIcL5EYnlxuPWjEOdauZK+FspkZDVdw==",
+      "version": "3.1040.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1040.0.tgz",
+      "integrity": "sha512-0KTpz2KqASQwzLOywV1bS2TX6Su0bARkATgpSu236BDM/D/6cMQ2EPiFwoRYwwvXsWSDn8KkKp9NV2ZWWA53Xw==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -876,9 +895,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1600,13 +1619,13 @@
       "peer": true
     },
     "node_modules/@mariozechner/pi-agent-core": {
-      "version": "0.70.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.70.5.tgz",
-      "integrity": "sha512-ZUnJ7fFeJog97KG8FewEyqaObY2sLWvfDurKHl9kImVEbgt3l1LJ9A5pb+4/5KXnCVsoF/Brd0h+7yBEd1Aj5g==",
+      "version": "0.70.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.70.6.tgz",
+      "integrity": "sha512-PovJZJqhY4ajgTJRUcLzfWKnlQuJHxHW3T030CafR9LYeLmOHi/HGS8DbCdRgSJNbnoIG+kl67/7++9DKZ2+sg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@mariozechner/pi-ai": "^0.70.5",
+        "@mariozechner/pi-ai": "^0.70.6",
         "typebox": "^1.1.24"
       },
       "engines": {
@@ -1614,9 +1633,9 @@
       }
     },
     "node_modules/@mariozechner/pi-ai": {
-      "version": "0.70.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.70.5.tgz",
-      "integrity": "sha512-eyeyOfu/YiqzY6q391oRYdmnPIIU1VTKAn3hWIvzqkRHkcArd41/YynG8mw6bgoLdmCnIBoY3fD6nzEHEHLIMA==",
+      "version": "0.70.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.70.6.tgz",
+      "integrity": "sha512-LVAadu0Y+hb7Bj7EDiLsx6AuGxHlxDq0euLzyqX698i9qt0BW6a+oQSUIZQz4rJwExF18OvyL7ygJ5781ojrIQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1849,16 +1868,16 @@
       }
     },
     "node_modules/@mariozechner/pi-coding-agent": {
-      "version": "0.70.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.70.5.tgz",
-      "integrity": "sha512-5sQjY2LQLvYfMjo4Dn6P6iy3LFm3MZYgrYmgCQSwQSUM5yqzWceidYYXS4knloW7gNkko+nnhKB2u4NF3w+dVw==",
+      "version": "0.70.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.70.6.tgz",
+      "integrity": "sha512-S4hUZghBeHPqsL6+DNg/TbGLziSh5+/mEHPVlYq5y6ImirWXhISLdLCnyZUW83OblKWihmG7unhJXiHQTH82mQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@mariozechner/jiti": "^2.6.2",
-        "@mariozechner/pi-agent-core": "^0.70.5",
-        "@mariozechner/pi-ai": "^0.70.5",
-        "@mariozechner/pi-tui": "^0.70.5",
+        "@mariozechner/pi-agent-core": "^0.70.6",
+        "@mariozechner/pi-ai": "^0.70.6",
+        "@mariozechner/pi-tui": "^0.70.6",
         "@silvia-odwyer/photon-node": "^0.3.4",
         "chalk": "^5.5.0",
         "cli-highlight": "^2.1.11",
@@ -1979,9 +1998,9 @@
       }
     },
     "node_modules/@mariozechner/pi-tui": {
-      "version": "0.70.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.70.5.tgz",
-      "integrity": "sha512-5Ol9weTqpsQ85gg1C6Mo8M8o/HYz4uN7nM7QTPrw/Rm/UoFgO1/T/Irago5aGfzlIj/nmsGcqb7NlkWtT4vXUg==",
+      "version": "0.70.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.70.6.tgz",
+      "integrity": "sha512-orBJEwMdpBC38AXfdVBKT5ZvqNTcKg6g3NdoF5a9aNQzDI/dOTu1UNYFYyEOTFRiTxSR1nw8eovbCcaSyekWfw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2037,9 +2056,9 @@
       }
     },
     "node_modules/@memorilabs/memori": {
-      "version": "0.1.11-beta",
-      "resolved": "https://registry.npmjs.org/@memorilabs/memori/-/memori-0.1.11-beta.tgz",
-      "integrity": "sha512-rNiPred+vHl6xtGJSJ1+5QgBdpMiVieY4llGg/aEFvvX7TKm8jTLwRawCMoPfSskr5aOaV1oQywT9Yt+SI3koA==",
+      "version": "0.1.12-beta",
+      "resolved": "https://registry.npmjs.org/@memorilabs/memori/-/memori-0.1.12-beta.tgz",
+      "integrity": "sha512-0wnZlzZfWyNt2nuwIKe4C87EESzvghSLdWzzSf8dSQXRiBIKzGrKOEyfMD/F2gNWIWk8oEubFUKKSU+zzIz+CQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@memorilabs/axon": "^0.1.5"
@@ -4240,26 +4259,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@vincentkoc/qrcode-tui": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@vincentkoc/qrcode-tui/-/qrcode-tui-0.2.1.tgz",
-      "integrity": "sha512-F2XVHMfasJ0q8G93gtcyU9Px0wMH6o6nIZLrZYSHc6dm9Pq3oCbHuVYYG/UQvJD0rhrGH3P9B6qgpCAqSDUw5w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "qrcode": "^1.5.4"
-      },
-      "bin": {
-        "qrcode-tui": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/vincentkoc"
       }
     },
     "node_modules/@vitest/coverage-v8": {
@@ -7394,9 +7393,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -7569,22 +7568,21 @@
       }
     },
     "node_modules/openclaw": {
-      "version": "2026.4.27",
-      "resolved": "https://registry.npmjs.org/openclaw/-/openclaw-2026.4.27.tgz",
-      "integrity": "sha512-99UOcRI6hOYGY76NmJQkMtBpuDjlkiCn5bAilMnDIaMG0mQOQjB8ZQ5pMzS1Zzos1ENJH8ddvBki6JwVaYPxRA==",
+      "version": "2026.4.29",
+      "resolved": "https://registry.npmjs.org/openclaw/-/openclaw-2026.4.29.tgz",
+      "integrity": "sha512-IRhX38ow4Hj783YxChK10rHwNg6OCupzGvVxG7EE24GaXHBumrESDpWUsgX0FiwTa0LYQBxuAcDncbyFiGVaOg==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@agentclientprotocol/sdk": "0.20.0",
+        "@agentclientprotocol/sdk": "0.21.0",
         "@clack/prompts": "^1.2.0",
         "@lydell/node-pty": "1.2.0-beta.12",
-        "@mariozechner/pi-agent-core": "0.70.5",
-        "@mariozechner/pi-ai": "0.70.5",
-        "@mariozechner/pi-coding-agent": "0.70.5",
-        "@mariozechner/pi-tui": "0.70.5",
+        "@mariozechner/pi-agent-core": "0.70.6",
+        "@mariozechner/pi-ai": "0.70.6",
+        "@mariozechner/pi-coding-agent": "0.70.6",
+        "@mariozechner/pi-tui": "0.70.6",
         "@modelcontextprotocol/sdk": "1.29.0",
-        "@vincentkoc/qrcode-tui": "0.2.1",
         "ajv": "^8.20.0",
         "chalk": "^5.6.2",
         "chokidar": "^5.0.0",
@@ -7600,13 +7598,13 @@
         "jszip": "^3.10.1",
         "markdown-it": "14.1.1",
         "openai": "^6.34.0",
-        "osc-progress": "^0.3.0",
         "proxy-agent": "^8.0.1",
+        "qrcode": "1.5.4",
         "semver": "7.7.4",
         "sqlite-vec": "0.1.9",
         "tar": "7.5.13",
         "tslog": "^4.10.2",
-        "typebox": "1.1.33",
+        "typebox": "1.1.34",
         "undici": "8.1.0",
         "web-push": "^3.6.7",
         "ws": "^8.20.0",
@@ -7673,16 +7671,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/osc-progress": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/osc-progress/-/osc-progress-0.3.0.tgz",
-      "integrity": "sha512-4/8JfsetakdeEa4vAYV45FW20aY+B/+K8NEXp5Eiar3wR8726whgHrbSg5Ar/ZY1FLJ/AGtUqV7W2IVF+Gvp9A==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/p-limit": {
@@ -7963,9 +7951,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
       "funding": [
         {
@@ -8823,9 +8811,9 @@
       }
     },
     "node_modules/socks/node_modules/ip-address": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.1.tgz",
-      "integrity": "sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -9294,9 +9282,9 @@
       }
     },
     "node_modules/typebox": {
-      "version": "1.1.33",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.33.tgz",
-      "integrity": "sha512-+/MWwlQ1q2GSVwoxi/+u5JsHkgLQKcCN2Nsjree9c+K7GJu40qbaHrFETmfV1i9Fs1TcOVfynW+jJvIWcXtvjw==",
+      "version": "1.1.34",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.34.tgz",
+      "integrity": "sha512-V0fM5W5DTXlEMDxqtX1dQ25HR1RQ11DPUVrIup4sJi1yQtIyI30SHfxBy/HjXKL1CtUqc5or2igA/wa/v4hMKQ==",
       "license": "MIT",
       "peer": true
     },

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorilabs/openclaw-memori",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Official MemoriLabs.ai long-term memory plugin for OpenClaw",
   "type": "module",
   "main": "./dist/index.js",
@@ -67,6 +67,6 @@
     "@hono/node-server": "^1.19.10"
   },
   "dependencies": {
-    "@memorilabs/memori": "0.1.11-beta"
+    "@memorilabs/memori": "0.1.12-beta"
   }
 }

--- a/integrations/openclaw/skills/clawhub/SKILL.md
+++ b/integrations/openclaw/skills/clawhub/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: memori
+id: '@memorilabs/openclaw-memori'
+description: Long-term memory for OpenClaw agents using the Memori SDK. Automatically captures conversations and equips the agent with explicit tools to recall context across sessions.
+license: MIT
+compatibility:
+  - openclaw
+metadata:
+  openclaw:
+    requires:
+      env:
+        - MEMORI_API_KEY
+        - ENTITY_ID
+        - PROJECT_ID
+      bins:
+        - memori
+    primaryEnv: MEMORI_API_KEY
+    externalServices:
+      - https://api.memorilabs.ai
+---
+
+# Memori - Structured Long-term Memory for OpenClaw
+
+Give your OpenClaw agents a persistent, structured memory system. Memori automatically captures what happens in the background and gives agents the tools to bring it back when relevant.
+
+## Core Workflow
+
+Memori operates on two parallel tracks through OpenClaw lifecycle hooks:
+
+### 1. Automatic Capture (Advanced Augmentation)
+
+After the agent responds, Memori automatically:
+
+1. Captures the conversation turn (user + assistant)
+2. Sends it to the Memori backend for intelligent processing
+3. Extracts durable facts, deduplicates, and updates the knowledge graph.
+   _(No manual save commands needed - capture just works)._
+
+### 2. Agent-Controlled Recall (Intelligent Retrieval)
+
+Memori does **not** blindly stuff the context window. Instead, it equips the agent with explicit tools to retrieve history exactly when it needs it:
+
+1. **`memori_recall`**: Searches the structured memory graph for specific facts, constraints, and prior decisions.
+2. **`memori_recall_summary`**: Retrieves structured daily briefs and rolling summaries of prior sessions.
+3. **`memori_feedback`**: Reports on memory quality to improve extraction accuracy.
+
+## Installation
+
+```bash
+openclaw plugins install @memorilabs/openclaw-memori
+```
+
+## Configuration
+
+Add to your `~/.openclaw/openclaw.json` or use the `openclaw memori init` CLI command:
+
+```bash
+openclaw memori init \
+  --api-key "YOUR_MEMORI_API_KEY" \
+  --entity-id "your-entity-id" \
+  --project-id "your-project-id"
+```
+
+Alternatively, configure it directly via JSON:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "openclaw-memori": {
+        "enabled": true,
+        "config": {
+          "apiKey": "${MEMORI_API_KEY}",
+          "entityId": "openclaw-user",
+          "projectId": "default-project"
+        }
+      }
+    }
+  }
+}
+```
+
+### Configuration Options
+
+- **apiKey** (required): Your Memori API key. If you don't have one, run `memori sign-up <your-email>` in your terminal or ask your OpenClaw agent to sign you up!
+- **entityId** (required): Unique identifier for this user's memories
+- **projectId** (required): Scopes all memories to a specific project or workspace
+
+## Agent Instructions & Skill Rules
+
+When this plugin is active, the OpenClaw agent is bound by the following strict behavioral rules injected into its system prompt:
+
+- **Manual Recall (IMPORTANT)**: The agent does NOT automatically receive context from past sessions. It is explicitly instructed: **"You must NEVER say 'I don't know' about the user, their preferences, or past events without FIRST running a `memori_recall` search to check if you remember it."**
+- **Summaries**: If a user asks "what did we do last time" or "give me a summary", the agent MUST use `memori_recall_summary` before answering. It is forbidden from guessing project status.
+- **Feedback**: The agent MUST use the `memori_feedback` tool immediately if the user asks to send feedback, report a bug, or suggests a feature.
+- **Date Defaults**: If the agent searches memory but omits start/end dates, the search defaults to **all-time memory**.
+
+## Verification
+
+Check that the plugin is working:
+
+```bash
+# Verify plugin is securely connected to the API
+openclaw memori status --check
+
+# Check for Memori logs in gateway output
+openclaw gateway logs --filter "[Memori]"
+```
+
+## Sign Up
+
+If you don't already have a Memori API key, you can sign up directly from the command line using the SDK's CLI:
+
+````bash
+memori sign-up <your-email@example.com>
+
+## Quota Management
+
+Check your current API quota:
+
+```bash
+memori quota
+````
+
+**Example output:**
+
+```
+ __  __                           _
+|  \/  | ___ _ __ ___   ___  _ __(_)
+| |\/| |/ _ \ '_ ` _ \ / _ \| '__| |
+| |  | |  __/ | | | | | (_) | |  | |
+|_|  |_|\___|_| |_| |_|\___/|_|  |_|
+                  perfectam memoriam
+                       memorilabs.ai
+
++ Maximum # of Memories: 100
++ Current # of Memories: 0
+
++ You are not currently over quota.
+```
+
+Use this to monitor usage and upgrade if needed.
+
+## Performance
+
+- **Automatic deduplication** prevents memory bloat
+- **Agent-controlled retrieval** ensures token usage remains targeted, compact, and actionable
+- **Semantic ranking** ensures relevant memories surface first
+
+## Privacy & Data Handling
+
+**Transparent data flow:**
+
+- ✅ Conversations sent to Memori backend (https://api.memorilabs.ai)
+- ✅ Data encrypted in transit and at rest
+- ✅ You control data via your API key and entityId
+- ✅ No third-party sharing
+- ⚠️ Only install if you trust Memori with conversation data
+
+Backend automatically filters sensitive data (API keys, passwords, secrets).
+
+For details: [Memori Privacy Policy](https://memorilabs.ai/privacy)
+
+## Memory Persistence
+
+Memories persist across:
+
+- Session restarts
+- Gateway restarts
+- System reboots
+- OpenClaw upgrades
+
+All storage is handled by the Memori backend and is scoped safely alongside your local `MEMORY.md` file without overwriting it.
+
+## Troubleshooting
+
+**Plugin not loading:**
+
+- Verify `enabled: true` in openclaw.json
+- Check API key: `echo $MEMORI_API_KEY`
+- Restart gateway: `openclaw gateway restart`
+
+**No memories captured:**
+
+- Check gateway logs for `[Memori]` errors
+- Verify API endpoint reachable
+- Test API key: `memori quota`
+
+**Memories not recalled:**
+
+- Did the agent actually use the tool? Check your gateway logs for `memori_recall` tool execution. If it didn't use the tool, explicitly ask it to search its memory.
+- Ensure `entityId` and `projectId` are consistent across sessions.
+- Verify memories exist: `memori quota` shows count > 0.
+
+**Quota exceeded:**
+
+- Run `memori quota` to check usage
+- Upgrade at [memorilabs.ai](https://app.memorilabs.ai/)
+- Or clear old memories via dashboard
+
+## Learn More
+
+- **npm Package**: https://www.npmjs.com/package/@memorilabs/openclaw-memori
+- **GitHub**: https://github.com/MemoriLabs/Memori
+- **Documentation**: https://memorilabs.ai/docs/memori-cloud/openclaw/overview/
+- **API Dashboard**: https://app.memorilabs.ai/
+- **Support**: [GitHub Issues](https://github.com/MemoriLabs/Memori/issues)
+
+## Notes
+
+This skill teaches the agent about the Memori plugin. The plugin must be installed separately via npm. Once installed, memory capture happens automatically in the background, and the agent is empowered to explicitly query its memories when needed.

--- a/integrations/openclaw/skills/clawhub/SKILL.md
+++ b/integrations/openclaw/skills/clawhub/SKILL.md
@@ -19,189 +19,290 @@ metadata:
       - https://api.memorilabs.ai
 ---
 
-# Memori - Structured Long-term Memory for OpenClaw
+# Memori skills file
 
-Give your OpenClaw agents a persistent, structured memory system. Memori automatically captures what happens in the background and gives agents the tools to bring it back when relevant.
+You have access to Memori, agent-native memory infrastructure: an LLM-agnostic layer that structures memory from not just natural language, but also from agent trace that comes from execution.
 
-## Core Workflow
+Memori automatically captures and structures memory from conversation and execution trace — including the agent's actions, tool results, decisions, and outcomes — and allows you to retrieve it on demand. Use it to maintain continuity across sessions, preserve decisions and constraints, and help the agent understand what it actually did so the next time it completes a task, it is more accurate and efficient.
 
-Memori operates on two parallel tracks through OpenClaw lifecycle hooks:
+---
 
-### 1. Automatic Capture (Advanced Augmentation)
+## Core instruction
 
-After the agent responds, Memori automatically:
+At the start of a session, you should check the `SKILL.md` file
 
-1. Captures the conversation turn (user + assistant)
-2. Sends it to the Memori backend for intelligent processing
-3. Extracts durable facts, deduplicates, and updates the knowledge graph.
-   _(No manual save commands needed - capture just works)._
+Use it to understand:
 
-### 2. Agent-Controlled Recall (Intelligent Retrieval)
+- Available capabilities
+- Tooling and integrations
+- Expected behaviors and constraints
 
-Memori does **not** blindly stuff the context window. Instead, it equips the agent with explicit tools to retrieve history exactly when it needs it:
+Treat `SKILL.md` as a source of truth for what you can do before taking action.
 
-1. **`memori_recall`**: Searches the structured memory graph for specific facts, constraints, and prior decisions.
-2. **`memori_recall_summary`**: Retrieves structured daily briefs and rolling summaries of prior sessions.
-3. **`memori_feedback`**: Reports on memory quality to improve extraction accuracy.
-4. **`memori_signup`**: Creates a Memori account and provisions an API key directly from the agent.
-5. **`memori_quota`**: Checks current memory usage and limits so the agent can degrade gracefully when approaching quota.
+---
 
-## Installation
+## When to use Memori
 
-```bash
-openclaw plugins install @memorilabs/openclaw-memori
-```
+Use Memori when:
 
-## Configuration
+- The task depends on prior context
+- The user refers to previous sessions or decisions
+- You need known constraints, preferences, or patterns
+- You are starting a session and need current state
+- You want to understand what has already been done
 
-Add to your `~/.openclaw/openclaw.json` or use the `openclaw memori init` CLI command:
+---
 
-```bash
-openclaw memori init \
-  --api-key "YOUR_MEMORI_API_KEY" \
-  --entity-id "your-entity-id" \
-  --project-id "your-project-id"
-```
+## When not to use Memori
 
-Alternatively, configure it directly via JSON:
+Do not use Memori when:
 
-```json
-{
-  "plugins": {
-    "entries": {
-      "openclaw-memori": {
-        "enabled": true,
-        "config": {
-          "apiKey": "${MEMORI_API_KEY}",
-          "entityId": "openclaw-user",
-          "projectId": "default-project"
-        }
-      }
-    }
-  }
-}
-```
+- The task is fully self-contained
+- The answer depends only on the current prompt
+- No historical context is required
+- The query is simple or one-off
 
-### Configuration Options
+Avoid unnecessary recall.
 
-- **apiKey** (required): Your Memori API key. If you don't have one, run `memori sign-up <your-email>` in your terminal or ask your OpenClaw agent to sign you up!
-- **entityId** (required): Unique identifier for this user's memories
-- **projectId** (required): Scopes all memories to a specific project or workspace
+---
 
-## Agent Instructions & Skill Rules
+## Recall behavior
 
-When this plugin is active, the OpenClaw agent is bound by the following strict behavioral rules injected into its system prompt:
+Recall is **agent-controlled and intentional**.
 
-- **Manual Recall (IMPORTANT)**: The agent does NOT automatically receive context from past sessions. It is explicitly instructed: **"You must NEVER say 'I don't know' about the user, their preferences, or past events without FIRST running a `memori_recall` search to check if you remember it."**
-- **Summaries**: If a user asks "what did we do last time" or "give me a summary", the agent MUST use `memori_recall_summary` before answering. It is forbidden from guessing project status.
-- **Feedback**: The agent MUST use the `memori_feedback` tool immediately if the user asks to send feedback, report a bug, or suggests a feature.
-- **Sign Up**: The agent MUST use `memori_signup` when the user asks to create an account or get an API key. It will ask for an email address if one is not provided.
-- **Quota**: The agent uses `memori_quota` when the user asks about usage limits, or proactively when it encounters errors suggesting limits have been reached.
-- **Date Defaults**: If the agent searches memory but omits start/end dates, recall defaults to **all-time memory** and summaries default to the **last 24 hours**.
+Prefer targeted recall over broad queries.
 
-## Verification
+### Supported parameters (recall only)
 
-Check that the plugin is working:
+- `entityId` → user, agent, or system context
+- `projectId` → project or workspace context
+- `sessionId` → specific session
+- `dateStart` / `dateEnd` → time-bounded recall
+- `source` → type of memory
+- `signal` → how the memory was derived
 
-```bash
-# Verify plugin is securely connected to the API
-openclaw memori status --check
+> Note: If a `sessionId` is provided, a `projectId` must also be provided.
+> All timestamps are stored in **UTC**.
 
-# Check for Memori logs in gateway output
-openclaw gateway logs --filter "[Memori]"
-```
+### Memory filters
 
-## Sign Up
+- `source`:
+  - constraint
+  - decision
+  - execution
+  - fact
+  - insight
+  - instruction
+  - status
+  - strategy
+  - task
 
-If you don't already have a Memori API key, you can sign up directly from the command line using the SDK's CLI:
+- `signal`:
+  - commit
+  - discovery
+  - failure
+  - inference
+  - pattern
+  - result
+  - update
+  - verification
 
-```bash
-memori sign-up <your-email@example.com>
-```
+Use `source` and `signal` to prioritize high-signal memory when possible.
 
-## Quota Management
+### Default behavior (recall)
 
-Check your current API quota:
+- No date range → **all-time memory**
+- Use time bounds when narrowing results is necessary
 
-```bash
-memori quota
-```
+### Best practices
 
-**Example output:**
+- Start narrow (entity + project)
+- Add time bounds only when needed
+- Use `source` and `signal` to refine results
+- Expand scope only if needed
+- Do not recall on every turn
 
-```
- __  __                           _
-|  \/  | ___ _ __ ___   ___  _ __(_)
-| |\/| |/ _ \ '_ ` _ \ / _ \| '__| |
-| |  | |  __/ | | | | | (_) | |  | |
-|_|  |_|\___|_| |_| |_|\___/|_|  |_|
-                  perfectam memoriam
-                       memorilabs.ai
+---
 
-+ Maximum # of Memories: 100
-+ Current # of Memories: 0
+## Summary behavior
 
-+ You are not currently over quota.
-```
+Summaries are used for **state awareness**, not precise retrieval.
 
-Use this to monitor usage and upgrade if needed.
+Use:
 
-## Performance
+- `memori_recall_summary`
 
-- **Automatic deduplication** prevents memory bloat
-- **Agent-controlled retrieval** ensures token usage remains targeted, compact, and actionable
-- **Semantic ranking** ensures relevant memories surface first
+### Supported parameters (summaries)
 
-## Privacy & Data Handling
+- `projectId`
+- `sessionId`
+- `dateStart`
+- `dateEnd`
 
-**Transparent data flow:**
+> Summaries do **not** support `source` or `signal`.
 
-- ✅ Conversations sent to Memori backend (https://api.memorilabs.ai)
-- ✅ Data encrypted in transit and at rest
-- ✅ You control data via your API key and entityId
-- ✅ No third-party sharing
-- ⚠️ Only install if you trust Memori with conversation data
+### Default behavior (summaries)
 
-Backend automatically filters sensitive data (API keys, passwords, secrets).
+- No date range → **last 24 hours**
 
-For details: [Memori Privacy Policy](https://memorilabs.ai/privacy)
+---
 
-## Memory Persistence
+## Daily brief behavior
 
-Memories persist across:
+At the start of a meaningful session, retrieve a structured summary.
 
-- Session restarts
-- Gateway restarts
-- System reboots
-- OpenClaw upgrades
+Use the daily brief to understand:
 
-All storage is handled by the Memori backend and is scoped safely alongside your local `MEMORY.md` file without overwriting it.
+- Current state
+- Prior decisions
+- Constraints
+- Open work
 
-## Troubleshooting
+### Expected daily brief structure
 
-**Plugin not loading:**
+- Today at a glance
+- Top 3 next actions
+- Top 3 risks
+- Verify before acting
+- Recent decisions
+- Mission stack
+- Hard constraints
+- Current status
+- Open loops
+- Known failures and anti-patterns
+- Staleness warnings
 
-- Verify `enabled: true` in openclaw.json
-- Check API key: `echo $MEMORI_API_KEY`
-- Restart gateway: `openclaw gateway restart`
+Treat this as the working state of the system.
 
-**No memories captured:**
+---
 
-- Check gateway logs for `[Memori]` errors
-- Verify API endpoint reachable
-- Test API key: `memori quota`
+## Typical workflow
 
-**Memories not recalled:**
+1. Start of session → retrieve summary
+2. During task → use targeted recall
+3. When memory is missing or incorrect → send feedback
+4. When limits are reached → degrade gracefully
 
-- Did the agent actually use the tool? Check your gateway logs for `memori_recall` tool execution. If it didn't use the tool, explicitly ask it to search its memory.
-- Ensure `entityId` and `projectId` are consistent across sessions.
-- Verify memories exist: `memori quota` shows count > 0.
+---
 
-**Quota exceeded:**
+## Safety and correctness
 
-- Run `memori quota` to check usage
-- Upgrade at [memorilabs.ai](https://app.memorilabs.ai/)
-- Or clear old memories via dashboard
+- Do not invent memory
+- Do not assume memory is correct if it conflicts with the user
+- Verify before acting when needed
+- Treat recent instructions as higher priority than recalled memory
+
+---
+
+## Memori system guidance
+
+This section defines how you should interact with Memori beyond basic recall.
+
+---
+
+### 1. Feedback (`memori_feedback`)
+
+You are equipped with the `memori_feedback` tool to improve memory quality over time.
+
+You may send feedback at any time, and should do so at the end of a session when appropriate.
+
+Feedback should be sent when:
+
+- Recall results are irrelevant or missing key context
+- Important decisions or constraints were not captured
+- Memory quality degrades across sessions
+- Something works particularly well and should be reinforced
+
+Examples:
+
+- "Send feedback that recall missed a pricing constraint."
+- "Tell Memori the daily brief was accurate."
+- "Submit a bug report: you didn't remember my preferred language."
+
+#### Purpose
+
+Feedback improves:
+
+- Memory extraction quality
+- Recall relevance
+- Summary accuracy
+
+---
+
+### 2. Updates
+
+Memori evolves over time (new features, improved recall, better summaries).
+
+When updates are exposed:
+
+- Check for updates via system message or tool
+- Adapt behavior to use new capabilities
+
+When an update is detected:
+
+- Prefer newer recall patterns when available
+- Use improved summaries or classification outputs
+- Continue operating normally if no changes are required
+
+---
+
+### 3. Account Creation and Onboarding (`memori_signup`)
+
+You are equipped with the `memori_signup` tool to securely create an account and provision an API key for the user via the Memori CLI.
+
+Use this tool when:
+
+- The user explicitly asks to sign up, create an account, or get an API key for Memori.
+- You encounter an error indicating a missing `MEMORI_API_KEY` and the user provides their email address to get one.
+
+#### Behavior:
+
+- **Email Required:** If the user asks to sign up but **does not** provide an email address, you MUST ask them for their email first. Do not attempt to guess or hallucinate an email.
+- **Execution:** Once they provide an email, run `memori_signup` with that email.
+- **Follow-up:** The tool will trigger the underlying CLI and return a success or error message. Relay that message to the user, remind them to check their inbox for the API key, and instruct them to add it to their configuration (`~/.openclaw/openclaw.json` or `.env` file).
+- **Troubleshooting Errors:** If the tool fails with a `Permission denied`, `EACCES`, or `command not found` error, do not ask the user for permission to troubleshoot. Instead, immediately tell them that their CLI installation is broken or missing, and explicitly instruct them to run `npm install -g @memorilabs/memori` in their terminal to fix it.
+
+---
+
+### 4. Quota Awareness and Upgrades (`memori_quota`)
+
+You are equipped with the `memori_quota` tool to check the user's current memory usage and limits via the Memori CLI.
+
+Use this tool when:
+
+- The user explicitly asks about their quota, usage, storage, or how many memories they have left.
+- You encounter errors suggesting memory limits have been reached and want to confirm before degrading behavior.
+
+#### Behavior:
+
+- **No Parameters Required:** Simply invoke `memori_quota` — it requires no arguments.
+- **Execution:** The tool runs the underlying CLI and returns the user's current usage and quota.
+- **Follow-up:** Relay the result clearly to the user. If they are near or at their limit, explain the impact and suggest an upgrade.
+- **Troubleshooting Errors:** If the tool fails with a `Permission denied`, `EACCES`, or `command not found` error, do not ask the user for permission to troubleshoot. Instead, immediately tell them that their CLI installation is broken or missing, and explicitly instruct them to run `npm install -g @memorilabs/memori` in their terminal to fix it.
+
+#### When limits are reached or nearing:
+
+#### a. Degrade gracefully
+
+- Reduce recall scope (shorter time ranges)
+- Prioritize high-signal memory (decisions, constraints, key facts)
+- Avoid unnecessary or repeated recall calls
+
+#### b. Inform the human/operator
+
+Clearly communicate when limits impact performance.
+
+Example:
+
+> "Memory limits have been reached. I can continue with limited recall, or you can upgrade to restore full functionality."
+
+#### c. Suggest upgrades appropriately
+
+- Only prompt when performance is affected
+- Avoid repetitive or disruptive messaging
+- Keep messaging neutral and helpful
+
+---
 
 ## Learn More
 
@@ -210,7 +311,3 @@ All storage is handled by the Memori backend and is scoped safely alongside your
 - **Documentation**: https://memorilabs.ai/docs/memori-cloud/openclaw/overview/
 - **API Dashboard**: https://app.memorilabs.ai/
 - **Support**: [GitHub Issues](https://github.com/MemoriLabs/Memori/issues)
-
-## Notes
-
-This skill teaches the agent about the Memori plugin. The plugin must be installed separately via npm. Once installed, memory capture happens automatically in the background, and the agent is empowered to explicitly query its memories when needed.

--- a/integrations/openclaw/skills/clawhub/SKILL.md
+++ b/integrations/openclaw/skills/clawhub/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: memori
 id: '@memorilabs/openclaw-memori'
-description: Long-term memory for OpenClaw agents using the Memori SDK. Automatically captures conversations and equips the agent with explicit tools to recall context across sessions.
+description: Long-term memory for OpenClaw agents using the Memori SDK. Automatically captures conversations and execution trace, and equips the agent with explicit tools to recall context, manage its account, and monitor usage across sessions.
 license: MIT
 compatibility:
   - openclaw
@@ -43,6 +43,8 @@ Memori does **not** blindly stuff the context window. Instead, it equips the age
 1. **`memori_recall`**: Searches the structured memory graph for specific facts, constraints, and prior decisions.
 2. **`memori_recall_summary`**: Retrieves structured daily briefs and rolling summaries of prior sessions.
 3. **`memori_feedback`**: Reports on memory quality to improve extraction accuracy.
+4. **`memori_signup`**: Creates a Memori account and provisions an API key directly from the agent.
+5. **`memori_quota`**: Checks current memory usage and limits so the agent can degrade gracefully when approaching quota.
 
 ## Installation
 
@@ -93,7 +95,9 @@ When this plugin is active, the OpenClaw agent is bound by the following strict 
 - **Manual Recall (IMPORTANT)**: The agent does NOT automatically receive context from past sessions. It is explicitly instructed: **"You must NEVER say 'I don't know' about the user, their preferences, or past events without FIRST running a `memori_recall` search to check if you remember it."**
 - **Summaries**: If a user asks "what did we do last time" or "give me a summary", the agent MUST use `memori_recall_summary` before answering. It is forbidden from guessing project status.
 - **Feedback**: The agent MUST use the `memori_feedback` tool immediately if the user asks to send feedback, report a bug, or suggests a feature.
-- **Date Defaults**: If the agent searches memory but omits start/end dates, the search defaults to **all-time memory**.
+- **Sign Up**: The agent MUST use `memori_signup` when the user asks to create an account or get an API key. It will ask for an email address if one is not provided.
+- **Quota**: The agent uses `memori_quota` when the user asks about usage limits, or proactively when it encounters errors suggesting limits have been reached.
+- **Date Defaults**: If the agent searches memory but omits start/end dates, recall defaults to **all-time memory** and summaries default to the **last 24 hours**.
 
 ## Verification
 
@@ -111,8 +115,9 @@ openclaw gateway logs --filter "[Memori]"
 
 If you don't already have a Memori API key, you can sign up directly from the command line using the SDK's CLI:
 
-````bash
+```bash
 memori sign-up <your-email@example.com>
+```
 
 ## Quota Management
 
@@ -120,7 +125,7 @@ Check your current API quota:
 
 ```bash
 memori quota
-````
+```
 
 **Example output:**
 

--- a/integrations/openclaw/skills/memori/SKILL.md
+++ b/integrations/openclaw/skills/memori/SKILL.md
@@ -6,6 +6,20 @@ Memori automatically captures and structures memory from conversation and execut
 
 ---
 
+## Core instruction
+
+At the start of a session, you should check the `SKILL.md` file
+
+Use it to understand:
+
+- Available capabilities
+- Tooling and integrations
+- Expected behaviors and constraints
+
+Treat `SKILL.md` as a source of truth for what you can do before taking action.
+
+---
+
 ## When to use Memori
 
 Use Memori when:

--- a/integrations/openclaw/skills/memori/skills.md
+++ b/integrations/openclaw/skills/memori/skills.md
@@ -1,65 +1,267 @@
-## Memori — Your Persistent Memory Layer
+# Memori skills file
 
-You have access to Memori, a structured long-term memory backend.
+You have access to Memori, a structured long-term memory system.
 
-**Automatic augmentation** (`agent_end`): After you respond, the conversation turn is automatically sent to Memori to extract and store facts, preferences, decisions, and relationships for future sessions. You do not need to do this manually.
-
-**Manual Recall (IMPORTANT)**: You do NOT automatically receive context from past sessions.
-**RULE:** You must NEVER say "I don't know" about the user, their preferences, or past events without FIRST running a `memori_recall` search to check if you remember it. If a user asks a question about themselves, you MUST search Memori before responding.
+Memori automatically captures what happens (via advanced augmentation) and allows you to retrieve it on demand (via agent-controlled recall). Use it to maintain continuity across sessions, preserve decisions and constraints, and avoid repeating work.
 
 ---
 
-### Memory Retrieval Tools
+## When to use Memori
 
-Use these to search your memory explicitly:
+Use Memori when:
 
-**`memori_recall`** — Fetch granular memory facts using a search query and optional filters. Use this when you need specific details (e.g., "what database did we choose?").
-
-| Parameter   | Type   | Description                                                                                                                                     |
-| ----------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `query`     | string | **Required.** A natural language semantic search query (e.g. "dogs"). **DO NOT use wildcards like `*`.**                                        |
-| `dateStart` | string | ISO 8601 (MUST be UTC) — memories on or after this time                                                                                         |
-| `dateEnd`   | string | ISO 8601 (MUST be UTC) — memories on or before this time                                                                                        |
-| `projectId` | string | CRITICAL: Leave EMPTY to use the current project. ONLY provide a value if the user explicitly names a different project.                        |
-| `sessionId` | string | Scope to a specific session — **requires `projectId`**                                                                                          |
-| `signal`    | string | Filter by signal type. Allowed values: `commit`, `discovery`, `failure`, `inference`, `pattern`, `result`, `update`, `verification`.            |
-| `source`    | string | Filter by source origin. Allowed values: `constraint`, `decision`, `execution`, `fact`, `insight`, `instruction`, `status`, `strategy`, `task`. |
-
-**`memori_recall_summary`** — Fetch summarized views of stored memories. **RULE:** You must NEVER guess or make up a status update, daily brief, or project overview. If the user asks "what did we do last time" or "give me a summary", you MUST use this tool before answering.
-
-| Parameter   | Type   | Description                                                                                                              |
-| ----------- | ------ | ------------------------------------------------------------------------------------------------------------------------ |
-| `dateStart` | string | ISO 8601 (MUST be UTC) — summaries on or after this time                                                                 |
-| `dateEnd`   | string | ISO 8601 (MUST be UTC) — summaries on or before this time                                                                |
-| `projectId` | string | CRITICAL: Leave EMPTY to use the current project. ONLY provide a value if the user explicitly names a different project. |
-| `sessionId` | string | Scope to a specific session — **requires `projectId`**                                                                   |
-
-> `sessionId` cannot be used without `projectId`. The backend will reject it.
+- The task depends on prior context
+- The user refers to previous sessions or decisions
+- You need known constraints, preferences, or patterns
+- You are starting a session and need current state
+- You want to understand what has already been done
 
 ---
 
-### Feedback Tool
+## When not to use Memori
 
-**RULE:** You must ALWAYS use this tool immediately if the user asks you to send feedback, report a bug, suggest a feature, or complains about the system. Do NOT just say "I will let the developers know"—you must actually execute the tool to send the message.
+Do not use Memori when:
 
-**`memori_feedback`** — Send feedback, suggestions, or issues directly to the Memori team.
+- The task is fully self-contained
+- The answer depends only on the current prompt
+- No historical context is required
+- The query is simple or one-off
 
-| Parameter | Type   | Description                                                              |
-| --------- | ------ | ------------------------------------------------------------------------ |
-| `content` | string | **Required.** The feedback text to send (positive, negative, bugs, etc.) |
-
-### Memory Scoping
-
-All memories are scoped to the current `entityId` and `projectId`. The current project is applied by default — you only need to pass `projectId` when explicitly overriding it for a cross-project lookup.
+Avoid unnecessary recall.
 
 ---
 
-### Coexistence With File Memory
+## Recall behavior
 
-Memori works alongside local file memory (e.g., `MEMORY.md`), it does not replace it:
+Recall is **agent-controlled and intentional**.
 
-| Layer                     | Scope                                 | Lifetime                    |
-| ------------------------- | ------------------------------------- | --------------------------- |
-| Session context           | Current conversation                  | Dies with session           |
-| File memory (`MEMORY.md`) | Curated strategic facts               | Persistent on disk          |
-| Memori                    | Auto-extracted facts, knowledge graph | Cloud — survives compaction |
+Prefer targeted recall over broad queries.
+
+### Supported parameters (recall only)
+
+- `entity_id` → user, agent, or system context
+- `project_id` → project or workspace context
+- `session_id` → specific session
+- `date_start` / `date_end` → time-bounded recall
+- `source` → type of memory
+- `signal` → how the memory was derived
+
+### Memory filters
+
+- `source`:
+  - constraint
+  - decision
+  - execution
+  - fact
+  - insight
+  - instruction
+  - status
+  - strategy
+  - task
+
+- `signal`:
+  - commit
+  - discovery
+  - failure
+  - inference
+  - pattern
+  - result
+  - update
+  - verification
+
+Use `source` and `signal` to prioritize high-signal memory when possible.
+
+### Default behavior (recall)
+
+- No date range → **all-time memory**
+- Use time bounds when narrowing results is necessary
+
+### Best practices
+
+- Start narrow (entity + project)
+- Add time bounds only when needed
+- Use `source` and `signal` to refine results
+- Expand scope only if needed
+- Do not recall on every turn
+
+---
+
+## Summary behavior
+
+Summaries are used for **state awareness**, not precise retrieval.
+
+Use:
+
+- `memori_recall_summary`
+
+### Supported parameters (summaries)
+
+- `project_id`
+- `session_id`
+- `date_start`
+- `date_end`
+
+> Summaries do **not** support `source` or `signal`.
+
+### Default behavior (summaries)
+
+- No date range → **last 24 hours**
+
+---
+
+## Daily brief behavior
+
+At the start of a meaningful session, retrieve a structured summary.
+
+Use the daily brief to understand:
+
+- Current state
+- Prior decisions
+- Constraints
+- Open work
+
+### Expected daily brief structure
+
+- Today at a glance
+- Top 3 next actions
+- Top 3 risks
+- Verify before acting
+- Recent decisions
+- Mission stack
+- Hard constraints
+- Current status
+- Open loops
+- Known failures and anti-patterns
+- Staleness warnings
+
+Treat this as the working state of the system.
+
+---
+
+## Typical workflow
+
+1. Start of session → retrieve summary
+2. During task → use targeted recall
+3. When memory is missing or incorrect → send feedback
+4. When limits are reached → degrade gracefully
+
+---
+
+## Safety and correctness
+
+- Do not invent memory
+- Do not assume memory is correct if it conflicts with the user
+- Verify before acting when needed
+- Treat recent instructions as higher priority than recalled memory
+
+---
+
+## Memori system guidance
+
+This section defines how you should interact with Memori beyond basic recall.
+
+---
+
+### 1. Feedback (`memori_feedback`)
+
+You are equipped with the `memori_feedback` tool to improve memory quality over time.
+
+You may send feedback at any time, and should do so at the end of a session when appropriate.
+
+Feedback should be sent when:
+
+- Recall results are irrelevant or missing key context
+- Important decisions or constraints were not captured
+- Memory quality degrades across sessions
+- Something works particularly well and should be reinforced
+
+Examples:
+
+- "Send feedback that recall missed a pricing constraint."
+- "Tell Memori the daily brief was accurate."
+- "Submit a bug report: you didn’t remember my preferred language."
+
+#### Purpose
+
+Feedback improves:
+
+- Memory extraction quality
+- Recall relevance
+- Summary accuracy
+
+---
+
+### 2. Updates
+
+Memori evolves over time (new features, improved recall, better summaries).
+
+When updates are exposed:
+
+- Check for updates via system message or tool
+- Adapt behavior to use new capabilities
+
+When an update is detected:
+
+- Prefer newer recall patterns when available
+- Use improved summaries or classification outputs
+- Continue operating normally if no changes are required
+
+---
+
+### 3. Account Creation and Onboarding (`memori_signup`)
+
+You are equipped with the `memori_signup` tool to securely create an account and provision an API key for the user via the Memori CLI.
+
+Use this tool when:
+
+- The user explicitly asks to sign up, create an account, or get an API key for Memori.
+- You encounter an error indicating a missing `MEMORI_API_KEY` and the user provides their email address to get one.
+
+#### Behavior:
+
+- **Email Required:** If the user asks to sign up but **does not** provide an email address, you MUST ask them for their email first. Do not attempt to guess or hallucinate an email.
+- **Execution:** Once they provide an email, run `memori_signup` with that email.
+- **Follow-up:** The tool will trigger the underlying CLI and return a success or error message. Relay that message to the user, remind them to check their inbox for the API key, and instruct them to add it to their configuration (`~/.openclaw/openclaw.json` or `.env` file).
+- **Troubleshooting Errors:** If the tool fails with a `Permission denied`, `EACCES`, or `command not found` error, do not ask the user for permission to troubleshoot. Instead, immediately tell them that their CLI installation is broken or missing, and explicitly instruct them to run `npm install -g @memorilabs/memori` in their terminal to fix it.
+
+---
+
+### 4. Quota Awareness and Upgrades (`memori_quota`)
+
+You are equipped with the `memori_quota` tool to check the user's current memory usage and limits via the Memori CLI.
+
+Use this tool when:
+
+- The user explicitly asks about their quota, usage, storage, or how many memories they have left.
+- You encounter errors suggesting memory limits have been reached and want to confirm before degrading behavior.
+
+#### Behavior:
+
+- **No Parameters Required:** Simply invoke `memori_quota` — it requires no arguments.
+- **Execution:** The tool runs the underlying CLI and returns the user's current usage and quota.
+- **Follow-up:** Relay the result clearly to the user. If they are near or at their limit, explain the impact and suggest an upgrade.
+- **Troubleshooting Errors:** If the tool fails with a `Permission denied`, `EACCES`, or `command not found` error, do not ask the user for permission to troubleshoot. Instead, immediately tell them that their CLI installation is broken or missing, and explicitly instruct them to run `npm install -g @memorilabs/memori` in their terminal to fix it.
+
+#### When limits are reached or nearing:
+
+#### a. Degrade gracefully
+
+- Reduce recall scope (shorter time ranges)
+- Prioritize high-signal memory (decisions, constraints, key facts)
+- Avoid unnecessary or repeated recall calls
+
+#### b. Inform the human/operator
+
+Clearly communicate when limits impact performance.
+
+Example:
+
+> “Memory limits have been reached. I can continue with limited recall, or you can upgrade to restore full functionality.”
+
+#### c. Suggest upgrades appropriately
+
+- Only prompt when performance is affected
+- Avoid repetitive or disruptive messaging
+- Keep messaging neutral and helpful
+
+---

--- a/integrations/openclaw/skills/memori/skills.md
+++ b/integrations/openclaw/skills/memori/skills.md
@@ -1,8 +1,8 @@
 # Memori skills file
 
-You have access to Memori, a structured long-term memory system.
+You have access to Memori, agent-native memory infrastructure: an LLM-agnostic layer that structures memory from not just natural language, but also from agent trace that comes from execution.
 
-Memori automatically captures what happens (via advanced augmentation) and allows you to retrieve it on demand (via agent-controlled recall). Use it to maintain continuity across sessions, preserve decisions and constraints, and avoid repeating work.
+Memori automatically captures and structures memory from conversation and execution trace — including the agent's actions, tool results, decisions, and outcomes — and allows you to retrieve it on demand. Use it to maintain continuity across sessions, preserve decisions and constraints, and help the agent understand what it actually did so the next time it completes a task, it is more accurate and efficient.
 
 ---
 
@@ -39,12 +39,15 @@ Prefer targeted recall over broad queries.
 
 ### Supported parameters (recall only)
 
-- `entity_id` → user, agent, or system context
-- `project_id` → project or workspace context
-- `session_id` → specific session
-- `date_start` / `date_end` → time-bounded recall
+- `entityId` → user, agent, or system context
+- `projectId` → project or workspace context
+- `sessionId` → specific session
+- `dateStart` / `dateEnd` → time-bounded recall
 - `source` → type of memory
 - `signal` → how the memory was derived
+
+> Note: If a `sessionId` is provided, a `projectId` must also be provided.
+> All timestamps are stored in **UTC**.
 
 ### Memory filters
 
@@ -96,10 +99,10 @@ Use:
 
 ### Supported parameters (summaries)
 
-- `project_id`
-- `session_id`
-- `date_start`
-- `date_end`
+- `projectId`
+- `sessionId`
+- `dateStart`
+- `dateEnd`
 
 > Summaries do **not** support `source` or `signal`.
 
@@ -179,7 +182,7 @@ Examples:
 
 - "Send feedback that recall missed a pricing constraint."
 - "Tell Memori the daily brief was accurate."
-- "Submit a bug report: you didn’t remember my preferred language."
+- "Submit a bug report: you didn't remember my preferred language."
 
 #### Purpose
 
@@ -256,7 +259,7 @@ Clearly communicate when limits impact performance.
 
 Example:
 
-> “Memory limits have been reached. I can continue with limited recall, or you can upgrade to restore full functionality.”
+> "Memory limits have been reached. I can continue with limited recall, or you can upgrade to restore full functionality."
 
 #### c. Suggest upgrades appropriately
 

--- a/integrations/openclaw/src/tools/index.ts
+++ b/integrations/openclaw/src/tools/index.ts
@@ -1,9 +1,13 @@
+import { createMemoriSignupTool } from './memori-signup.js';
+import { createMemoriQuotaTool } from './memori-quota.js';
 import { createMemoriRecallTool } from './memori-recall.js';
 import { createMemoriRecallSummaryTool } from './memori-recall-summary.js';
 import { createMemoriFeedbackTool } from './memori-feedback.js';
 import type { ToolDeps } from './types.js';
 
 export function registerAllTools(deps: ToolDeps): void {
+  deps.api.registerTool(createMemoriSignupTool(deps));
+  deps.api.registerTool(createMemoriQuotaTool(deps));
   deps.api.registerTool(createMemoriRecallTool(deps));
   deps.api.registerTool(createMemoriRecallSummaryTool(deps));
   deps.api.registerTool(createMemoriFeedbackTool(deps));

--- a/integrations/openclaw/src/tools/memori-quota.ts
+++ b/integrations/openclaw/src/tools/memori-quota.ts
@@ -1,0 +1,70 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import * as os from 'os';
+import * as path from 'path';
+import type { ToolDeps } from './types.js';
+
+const execAsync = promisify(exec);
+
+export function createMemoriQuotaTool(deps: ToolDeps) {
+  const { logger } = deps;
+
+  return {
+    name: 'memori_quota',
+    label: 'Memori Quota',
+    description:
+      'Retrieves the current memory usage and maximum allowed quota for the user. Use this when the user asks about their limits, storage, or how many memories they have left.',
+    parameters: {
+      type: 'object',
+      properties: {},
+    },
+
+    async execute(_toolCallId: string) {
+      try {
+        logger.info('memori_quota checking usage...');
+
+        const tmpDir = os.tmpdir();
+
+        await execAsync(`npm install --prefix ${tmpDir} --no-save @memorilabs/memori@0.1.12-beta`);
+
+        const binPath = path.join(tmpDir, 'node_modules', '.bin', 'memori');
+        const { stdout } = await execAsync(`${binPath} quota`);
+
+        const result = {
+          success: true,
+          message: stdout.trim(),
+        };
+
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+          details: null,
+        };
+      } catch (e: unknown) {
+        logger.warn(`memori_quota CLI failed: ${String(e)}`);
+
+        let output = 'An unexpected error occurred while trying to fetch quota via the CLI.';
+
+        if (typeof e === 'object' && e !== null) {
+          const errObj = e as Record<string, unknown>;
+
+          const stdout = typeof errObj.stdout === 'string' ? errObj.stdout.trim() : '';
+          const stderr = typeof errObj.stderr === 'string' ? errObj.stderr.trim() : '';
+          const msg = typeof errObj.message === 'string' ? errObj.message : '';
+
+          output = stdout || stderr || msg || output;
+        } else if (typeof e === 'string') {
+          output = e;
+        }
+
+        const errorResult = {
+          error: output,
+        };
+
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(errorResult) }],
+          details: null,
+        };
+      }
+    },
+  };
+}

--- a/integrations/openclaw/src/tools/memori-quota.ts
+++ b/integrations/openclaw/src/tools/memori-quota.ts
@@ -13,7 +13,7 @@ export function createMemoriQuotaTool(deps: ToolDeps) {
     name: 'memori_quota',
     label: 'Memori Quota',
     description:
-      'Retrieves the current memory usage and maximum allowed quota for the user. Use this when the user asks about their limits, storage, or how many memories they have left.',
+      'Retrieves the current memory usage and maximum allowed quota for the user. Use this when the user asks about their limits, storage, or how many memories they have left — or when you encounter errors suggesting memory limits have been reached and want to confirm before degrading behavior.',
     parameters: {
       type: 'object',
       properties: {},

--- a/integrations/openclaw/src/tools/memori-recall-summary.ts
+++ b/integrations/openclaw/src/tools/memori-recall-summary.ts
@@ -8,7 +8,7 @@ export function createMemoriRecallSummaryTool(deps: ToolDeps) {
     name: 'memori_recall_summary',
     label: 'Recall Memory Summary',
     description:
-      'CRITICAL: You MUST use this tool BEFORE answering any requests for a summary, status update, daily brief, or high-level overview of a project or past sessions. Fetch summarized views of stored memories from Memori within a specific date range.',
+      'CRITICAL: You MUST use this tool BEFORE answering any requests for a summary, status update, daily brief, or high-level overview of a project or past sessions. Fetch summarized views of stored memories from Memori within a specific date range. If no date range is provided, the result defaults to the last 24 hours.',
     parameters: {
       type: 'object',
       properties: {

--- a/integrations/openclaw/src/tools/memori-signup.ts
+++ b/integrations/openclaw/src/tools/memori-signup.ts
@@ -1,0 +1,93 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import * as os from 'os';
+import * as path from 'path';
+import type { ToolDeps } from './types.js';
+
+const execAsync = promisify(exec);
+
+export function createMemoriSignupTool(deps: ToolDeps) {
+  const { logger } = deps;
+
+  return {
+    name: 'memori_signup',
+    label: 'Memori Sign Up',
+    description:
+      'Signs up a user for a Memori API key. Safely downloads and runs the CLI in an isolated temporary sandbox.',
+    parameters: {
+      type: 'object',
+      properties: {
+        email: {
+          type: 'string',
+          description: 'The email address to send the Memori API key to.',
+        },
+      },
+      required: ['email'],
+    },
+
+    async execute(
+      _toolCallId: string,
+      params: {
+        email: string;
+      }
+    ) {
+      try {
+        const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+        if (!emailRegex.test(params.email)) {
+          const errorResult = {
+            error: `The email you provided "${params.email}" is not valid. Please provide a standard email address.`,
+          };
+          logger.warn(`memori_signup rejected email format: ${params.email}`);
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify(errorResult) }],
+            details: null,
+          };
+        }
+
+        logger.info(`memori_signup attempting to sign up: ${params.email}`);
+
+        const tmpDir = os.tmpdir();
+
+        await execAsync(`npm install --prefix ${tmpDir} --no-save @memorilabs/memori@0.1.12-beta`);
+
+        const binPath = path.join(tmpDir, 'node_modules', '.bin', 'memori');
+        const { stdout } = await execAsync(`${binPath} sign-up ${params.email}`);
+
+        const result = {
+          success: true,
+          message: stdout.trim(),
+        };
+
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+          details: null,
+        };
+      } catch (e: unknown) {
+        logger.warn(`memori_signup CLI failed: ${String(e)}`);
+
+        let output = 'An unexpected error occurred while trying to sign up via the CLI.';
+
+        if (typeof e === 'object' && e !== null) {
+          const errObj = e as Record<string, unknown>;
+
+          const stdout = typeof errObj.stdout === 'string' ? errObj.stdout.trim() : '';
+          const stderr = typeof errObj.stderr === 'string' ? errObj.stderr.trim() : '';
+          const msg = typeof errObj.message === 'string' ? errObj.message : '';
+
+          output = stdout || stderr || msg || output;
+        } else if (typeof e === 'string') {
+          output = e;
+        }
+
+        const errorResult = {
+          error: output,
+        };
+
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(errorResult) }],
+          details: null,
+        };
+      }
+    },
+  };
+}

--- a/integrations/openclaw/src/tools/memori-signup.ts
+++ b/integrations/openclaw/src/tools/memori-signup.ts
@@ -13,7 +13,7 @@ export function createMemoriSignupTool(deps: ToolDeps) {
     name: 'memori_signup',
     label: 'Memori Sign Up',
     description:
-      'Signs up a user for a Memori API key. Safely downloads and runs the CLI in an isolated temporary sandbox.',
+      'CRITICAL: You MUST use this tool when the user asks to sign up, create an account, or get an API key for Memori — or when you encounter a missing MEMORI_API_KEY error and the user provides their email. If the user has not provided an email address, ask for it first. Do not guess or hallucinate an email.',
     parameters: {
       type: 'object',
       properties: {

--- a/integrations/openclaw/src/utils/skills-loader.ts
+++ b/integrations/openclaw/src/utils/skills-loader.ts
@@ -7,7 +7,7 @@ import { readFileSync } from 'fs';
  */
 export function loadSkillsContent(resolvePath: (input: string) => string): string {
   try {
-    return readFileSync(resolvePath('skills/memori/skills.md'), 'utf-8');
+    return readFileSync(resolvePath('skills/memori/SKILL.md'), 'utf-8');
   } catch {
     return '';
   }

--- a/integrations/openclaw/tests/tools/memori-quota.test.ts
+++ b/integrations/openclaw/tests/tools/memori-quota.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { exec } from 'child_process';
+import { createMemoriQuotaTool } from '../../src/tools/memori-quota.js';
+import type { ToolDeps } from '../../src/tools/types.js';
+
+vi.mock('child_process', () => ({
+  exec: vi.fn(),
+}));
+
+vi.mock('os', () => ({
+  tmpdir: vi.fn(() => '/mock-tmp'),
+}));
+
+describe('tools/memori-quota', () => {
+  const mockExec = vi.mocked(exec) as any;
+  let deps: ToolDeps;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockExec.mockImplementation((_cmd: string, cb: Function) => {
+      cb(null, { stdout: 'default output', stderr: '' });
+      return {} as any;
+    });
+
+    deps = {
+      api: {} as any,
+      config: { apiKey: 'test-key', entityId: 'test-entity', projectId: 'default-project' },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        section: vi.fn(),
+        endSection: vi.fn(),
+      } as any,
+    };
+  });
+
+  describe('tool definition', () => {
+    it('should have the correct name', () => {
+      expect(createMemoriQuotaTool(deps).name).toBe('memori_quota');
+    });
+
+    it('should have the correct label', () => {
+      expect(createMemoriQuotaTool(deps).label).toBe('Memori Quota');
+    });
+
+    it('should have a description', () => {
+      expect(createMemoriQuotaTool(deps).description).toBeTruthy();
+    });
+
+    it('should have no required parameters', () => {
+      const { parameters } = createMemoriQuotaTool(deps);
+      expect((parameters as any).required).toBeUndefined();
+    });
+
+    it('should have no parameter properties defined', () => {
+      const { parameters } = createMemoriQuotaTool(deps);
+      expect(Object.keys(parameters.properties)).toHaveLength(0);
+    });
+  });
+
+  describe('execute', () => {
+    it('should install the package into the tmp directory', async () => {
+      const tool = createMemoriQuotaTool(deps);
+      await tool.execute('call-1');
+      expect(mockExec.mock.calls[0][0]).toContain('npm install --prefix /mock-tmp');
+      expect(mockExec.mock.calls[0][0]).toContain('@memorilabs/memori');
+    });
+
+    it('should run quota using the explicit binary path in tmp', async () => {
+      const tool = createMemoriQuotaTool(deps);
+      await tool.execute('call-1');
+      expect(mockExec.mock.calls[1][0]).toBe('/mock-tmp/node_modules/.bin/memori quota');
+    });
+
+    it('should return success: true with trimmed CLI stdout', async () => {
+      mockExec
+        .mockImplementationOnce((_cmd: string, cb: Function) => {
+          cb(null, { stdout: '', stderr: '' });
+          return {} as any;
+        })
+        .mockImplementationOnce((_cmd: string, cb: Function) => {
+          cb(null, { stdout: '  Used: 42 / 1000  \n', stderr: '' });
+          return {} as any;
+        });
+
+      const tool = createMemoriQuotaTool(deps);
+      const result = await tool.execute('call-1');
+      expect(JSON.parse(result.content[0].text)).toEqual({
+        success: true,
+        message: 'Used: 42 / 1000',
+      });
+    });
+
+    it('should return details: null on success', async () => {
+      const tool = createMemoriQuotaTool(deps);
+      const result = await tool.execute('call-1');
+      expect(result.details).toBeNull();
+    });
+
+    it('should log info before executing', async () => {
+      const tool = createMemoriQuotaTool(deps);
+      await tool.execute('call-1');
+      expect(deps.logger.info).toHaveBeenCalledWith(expect.stringContaining('memori_quota'));
+    });
+
+    it('should call exec exactly twice on success', async () => {
+      const tool = createMemoriQuotaTool(deps);
+      await tool.execute('call-1');
+      expect(mockExec).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should return error JSON and log warn on exec failure', async () => {
+      mockExec.mockImplementation((_cmd: string, cb: Function) => {
+        cb(new Error('exec failed'));
+        return {} as any;
+      });
+
+      const tool = createMemoriQuotaTool(deps);
+      const result = await tool.execute('call-1');
+      expect(JSON.parse(result.content[0].text)).toHaveProperty('error');
+      expect(deps.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('memori_quota CLI failed')
+      );
+    });
+
+    it('should use error.stdout when present', async () => {
+      mockExec.mockImplementation((_cmd: string, cb: Function) => {
+        cb(Object.assign(new Error(), { stdout: 'stdout detail', stderr: '' }));
+        return {} as any;
+      });
+
+      const tool = createMemoriQuotaTool(deps);
+      const result = await tool.execute('call-1');
+      expect(JSON.parse(result.content[0].text).error).toBe('stdout detail');
+    });
+
+    it('should fall back to error.stderr when stdout is empty', async () => {
+      mockExec.mockImplementation((_cmd: string, cb: Function) => {
+        cb(Object.assign(new Error(), { stdout: '', stderr: 'stderr detail' }));
+        return {} as any;
+      });
+
+      const tool = createMemoriQuotaTool(deps);
+      const result = await tool.execute('call-1');
+      expect(JSON.parse(result.content[0].text).error).toBe('stderr detail');
+    });
+
+    it('should fall back to error.message when stdout and stderr are empty', async () => {
+      mockExec.mockImplementation((_cmd: string, cb: Function) => {
+        cb(Object.assign(new Error('message detail'), { stdout: '', stderr: '' }));
+        return {} as any;
+      });
+
+      const tool = createMemoriQuotaTool(deps);
+      const result = await tool.execute('call-1');
+      expect(JSON.parse(result.content[0].text).error).toBe('message detail');
+    });
+
+    it('should use a default message when the error has no useful fields', async () => {
+      mockExec.mockImplementation((_cmd: string, cb: Function) => {
+        cb({});
+        return {} as any;
+      });
+
+      const tool = createMemoriQuotaTool(deps);
+      const result = await tool.execute('call-1');
+      expect(JSON.parse(result.content[0].text).error).toContain('unexpected error');
+    });
+
+    it('should handle a plain string error', async () => {
+      mockExec.mockImplementation((_cmd: string, cb: Function) => {
+        cb('plain string error');
+        return {} as any;
+      });
+
+      const tool = createMemoriQuotaTool(deps);
+      const result = await tool.execute('call-1');
+      expect(JSON.parse(result.content[0].text).error).toBe('plain string error');
+    });
+
+    it('should trim whitespace from error.stdout', async () => {
+      mockExec.mockImplementation((_cmd: string, cb: Function) => {
+        cb(Object.assign(new Error(), { stdout: '  trimmed error  \n', stderr: '' }));
+        return {} as any;
+      });
+
+      const tool = createMemoriQuotaTool(deps);
+      const result = await tool.execute('call-1');
+      expect(JSON.parse(result.content[0].text).error).toBe('trimmed error');
+    });
+
+    it('should return details: null on error', async () => {
+      mockExec.mockImplementation((_cmd: string, cb: Function) => {
+        cb(new Error('failed'));
+        return {} as any;
+      });
+
+      const tool = createMemoriQuotaTool(deps);
+      const result = await tool.execute('call-1');
+      expect(result.details).toBeNull();
+    });
+  });
+});

--- a/integrations/openclaw/tests/tools/memori-signup.test.ts
+++ b/integrations/openclaw/tests/tools/memori-signup.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { exec } from 'child_process';
+import { createMemoriSignupTool } from '../../src/tools/memori-signup.js';
+import type { ToolDeps } from '../../src/tools/types.js';
+
+vi.mock('child_process', () => ({
+  exec: vi.fn(),
+}));
+
+vi.mock('os', () => ({
+  tmpdir: vi.fn(() => '/mock-tmp'),
+}));
+
+describe('tools/memori-signup', () => {
+  const mockExec = vi.mocked(exec) as any;
+  let deps: ToolDeps;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockExec.mockImplementation((_cmd: string, cb: Function) => {
+      cb(null, { stdout: 'default output', stderr: '' });
+      return {} as any;
+    });
+
+    deps = {
+      api: {} as any,
+      config: { apiKey: 'test-key', entityId: 'test-entity', projectId: 'default-project' },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        section: vi.fn(),
+        endSection: vi.fn(),
+      } as any,
+    };
+  });
+
+  describe('tool definition', () => {
+    it('should have the correct name', () => {
+      expect(createMemoriSignupTool(deps).name).toBe('memori_signup');
+    });
+
+    it('should have the correct label', () => {
+      expect(createMemoriSignupTool(deps).label).toBe('Memori Sign Up');
+    });
+
+    it('should have a description', () => {
+      expect(createMemoriSignupTool(deps).description).toBeTruthy();
+    });
+
+    it('should define the email parameter as a string', () => {
+      const { parameters } = createMemoriSignupTool(deps);
+      expect((parameters.properties as any).email).toBeDefined();
+      expect((parameters.properties as any).email.type).toBe('string');
+    });
+
+    it('should require the email parameter', () => {
+      expect(createMemoriSignupTool(deps).parameters.required).toContain('email');
+    });
+  });
+
+  describe('email validation', () => {
+    const invalidEmails = [
+      'notanemail',
+      '@domain.com',
+      'user@',
+      '',
+      'user@domain',
+      'user @example.com',
+      'user@.com',
+    ];
+
+    for (const email of invalidEmails) {
+      it(`should reject invalid email: "${email}"`, async () => {
+        const tool = createMemoriSignupTool(deps);
+        const result = await tool.execute('call-1', { email });
+        expect(JSON.parse(result.content[0].text)).toHaveProperty('error');
+        expect(mockExec).not.toHaveBeenCalled();
+      });
+    }
+
+    it('should include the invalid email in the error message', async () => {
+      const tool = createMemoriSignupTool(deps);
+      const result = await tool.execute('call-1', { email: 'bademail' });
+      expect(JSON.parse(result.content[0].text).error).toContain('bademail');
+    });
+
+    it('should log a warning for an invalid email', async () => {
+      const tool = createMemoriSignupTool(deps);
+      await tool.execute('call-1', { email: 'bad' });
+      expect(deps.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('memori_signup rejected email format')
+      );
+    });
+
+    it('should accept a standard email', async () => {
+      const tool = createMemoriSignupTool(deps);
+      const result = await tool.execute('call-1', { email: 'user@example.com' });
+      expect(JSON.parse(result.content[0].text)).toHaveProperty('success', true);
+    });
+
+    it('should accept an email with subdomains', async () => {
+      const tool = createMemoriSignupTool(deps);
+      const result = await tool.execute('call-1', { email: 'user@mail.example.co.uk' });
+      expect(JSON.parse(result.content[0].text)).toHaveProperty('success', true);
+    });
+
+    it('should accept an email with plus addressing', async () => {
+      const tool = createMemoriSignupTool(deps);
+      const result = await tool.execute('call-1', { email: 'user+tag@example.com' });
+      expect(JSON.parse(result.content[0].text)).toHaveProperty('success', true);
+    });
+  });
+
+  describe('execute', () => {
+    it('should install the package into the tmp directory', async () => {
+      const tool = createMemoriSignupTool(deps);
+      await tool.execute('call-1', { email: 'user@example.com' });
+      expect(mockExec.mock.calls[0][0]).toContain('npm install --prefix /mock-tmp');
+      expect(mockExec.mock.calls[0][0]).toContain('@memorilabs/memori');
+    });
+
+    it('should run sign-up using the explicit binary path in tmp', async () => {
+      const tool = createMemoriSignupTool(deps);
+      await tool.execute('call-1', { email: 'user@example.com' });
+      expect(mockExec.mock.calls[1][0]).toContain('/mock-tmp/node_modules/.bin/memori');
+      expect(mockExec.mock.calls[1][0]).toContain('sign-up user@example.com');
+    });
+
+    it('should return success: true with trimmed CLI stdout', async () => {
+      mockExec
+        .mockImplementationOnce((_cmd: string, cb: Function) => {
+          cb(null, { stdout: '', stderr: '' });
+          return {} as any;
+        })
+        .mockImplementationOnce((_cmd: string, cb: Function) => {
+          cb(null, { stdout: '  Your key is on the way!  \n', stderr: '' });
+          return {} as any;
+        });
+
+      const tool = createMemoriSignupTool(deps);
+      const result = await tool.execute('call-1', { email: 'user@example.com' });
+      expect(JSON.parse(result.content[0].text)).toEqual({
+        success: true,
+        message: 'Your key is on the way!',
+      });
+    });
+
+    it('should return details: null on success', async () => {
+      const tool = createMemoriSignupTool(deps);
+      const result = await tool.execute('call-1', { email: 'user@example.com' });
+      expect(result.details).toBeNull();
+    });
+
+    it('should log info with the email before executing', async () => {
+      const tool = createMemoriSignupTool(deps);
+      await tool.execute('call-1', { email: 'user@example.com' });
+      expect(deps.logger.info).toHaveBeenCalledWith(expect.stringContaining('user@example.com'));
+    });
+
+    it('should call exec exactly twice on success', async () => {
+      const tool = createMemoriSignupTool(deps);
+      await tool.execute('call-1', { email: 'user@example.com' });
+      expect(mockExec).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should return error JSON and log warn on exec failure', async () => {
+      mockExec.mockImplementation((_cmd: string, cb: Function) => {
+        cb(new Error('exec failed'));
+        return {} as any;
+      });
+
+      const tool = createMemoriSignupTool(deps);
+      const result = await tool.execute('call-1', { email: 'user@example.com' });
+      expect(JSON.parse(result.content[0].text)).toHaveProperty('error');
+      expect(deps.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('memori_signup CLI failed')
+      );
+    });
+
+    it('should use error.stdout when present', async () => {
+      mockExec.mockImplementation((_cmd: string, cb: Function) => {
+        cb(Object.assign(new Error(), { stdout: 'stdout detail', stderr: '' }));
+        return {} as any;
+      });
+
+      const tool = createMemoriSignupTool(deps);
+      const result = await tool.execute('call-1', { email: 'user@example.com' });
+      expect(JSON.parse(result.content[0].text).error).toBe('stdout detail');
+    });
+
+    it('should fall back to error.stderr when stdout is empty', async () => {
+      mockExec.mockImplementation((_cmd: string, cb: Function) => {
+        cb(Object.assign(new Error(), { stdout: '', stderr: 'stderr detail' }));
+        return {} as any;
+      });
+
+      const tool = createMemoriSignupTool(deps);
+      const result = await tool.execute('call-1', { email: 'user@example.com' });
+      expect(JSON.parse(result.content[0].text).error).toBe('stderr detail');
+    });
+
+    it('should fall back to error.message when stdout and stderr are empty', async () => {
+      mockExec.mockImplementation((_cmd: string, cb: Function) => {
+        cb(Object.assign(new Error('message detail'), { stdout: '', stderr: '' }));
+        return {} as any;
+      });
+
+      const tool = createMemoriSignupTool(deps);
+      const result = await tool.execute('call-1', { email: 'user@example.com' });
+      expect(JSON.parse(result.content[0].text).error).toBe('message detail');
+    });
+
+    it('should use a default message when the error has no useful fields', async () => {
+      mockExec.mockImplementation((_cmd: string, cb: Function) => {
+        cb({});
+        return {} as any;
+      });
+
+      const tool = createMemoriSignupTool(deps);
+      const result = await tool.execute('call-1', { email: 'user@example.com' });
+      expect(JSON.parse(result.content[0].text).error).toContain('unexpected error');
+    });
+
+    it('should handle a plain string error', async () => {
+      mockExec.mockImplementation((_cmd: string, cb: Function) => {
+        cb('plain string error');
+        return {} as any;
+      });
+
+      const tool = createMemoriSignupTool(deps);
+      const result = await tool.execute('call-1', { email: 'user@example.com' });
+      expect(JSON.parse(result.content[0].text).error).toBe('plain string error');
+    });
+
+    it('should trim whitespace from error.stdout', async () => {
+      mockExec.mockImplementation((_cmd: string, cb: Function) => {
+        cb(Object.assign(new Error(), { stdout: '  trimmed error  \n', stderr: '' }));
+        return {} as any;
+      });
+
+      const tool = createMemoriSignupTool(deps);
+      const result = await tool.execute('call-1', { email: 'user@example.com' });
+      expect(JSON.parse(result.content[0].text).error).toBe('trimmed error');
+    });
+
+    it('should return details: null on error', async () => {
+      mockExec.mockImplementation((_cmd: string, cb: Function) => {
+        cb(new Error('failed'));
+        return {} as any;
+      });
+
+      const tool = createMemoriSignupTool(deps);
+      const result = await tool.execute('call-1', { email: 'user@example.com' });
+      expect(result.details).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
-Add CLI-backed Memori tools for OpenClaw: memori_signup and memori_quota (src/tools/*.ts) and register them in tools index. 
-Include unit tests for quota and signup,
- add OpenClaw skill docs (skills/clawhub/SKILL.md) and expanded memori skill guidance. 
- Bump package version to 0.0.10 and update @memorilabs/memori dependency to 0.1.12-beta (with corresponding package-lock changes).