### PR TITLE
Remove limit from memori-recall tool

### DIFF
--- a/integrations/openclaw/src/tools/memori-recall.ts
+++ b/integrations/openclaw/src/tools/memori-recall.ts
@@ -17,10 +17,6 @@ export function createMemoriRecallTool(deps: ToolDeps) {
           description:
             'REQUIRED: The natural language search query to find specific facts (e.g., "What database did we decide to use?", "Ryan\'s dogs"). DO NOT use wildcards like "*" or regex. This is a semantic search, so use real words.',
         },
-        limit: {
-          type: 'number',
-          description: 'Maximum number of memories to return (default: 10)',
-        },
         dateStart: {
           type: 'string',
           description:

--- a/integrations/openclaw/tests/tools/memori-recall.test.ts
+++ b/integrations/openclaw/tests/tools/memori-recall.test.ts
@@ -43,7 +43,6 @@ describe('tools/memori-recall', () => {
       const tool = createMemoriRecallTool(deps);
       const props = tool.parameters.properties;
       expect(props).toHaveProperty('query');
-      expect(props).toHaveProperty('limit');
       expect(props).toHaveProperty('dateStart');
       expect(props).toHaveProperty('dateEnd');
       expect(props).toHaveProperty('projectId');
@@ -93,7 +92,6 @@ describe('tools/memori-recall', () => {
 
       await tool.execute('call-1', {
         query: 'search query',
-        limit: 5,
         dateStart: '2024-01-01',
         dateEnd: '2024-12-31',
         projectId: 'proj-1',
@@ -106,7 +104,6 @@ describe('tools/memori-recall', () => {
       expect(client.agentRecall).toHaveBeenCalledWith(
         expect.objectContaining({
           query: 'search query',
-          limit: 5,
           dateStart: '2024-01-01',
           dateEnd: '2024-12-31',
           projectId: 'proj-1',

--- a/integrations/openclaw/tests/utils/skills-loader.test.ts
+++ b/integrations/openclaw/tests/utils/skills-loader.test.ts
@@ -7,7 +7,7 @@ vi.mock('fs', () => ({
 import { loadSkillsContent } from '../../src/utils/skills-loader.js';
 
 describe('utils/skills-loader', () => {
-  let mockResolvePath: ReturnType<typeof vi.fn>;
+  let mockResolvePath: (input: string) => string;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -20,8 +20,8 @@ describe('utils/skills-loader', () => {
 
     loadSkillsContent(mockResolvePath);
 
-    expect(mockResolvePath).toHaveBeenCalledWith('skills/memori/skills.md');
-    expect(readFileSync).toHaveBeenCalledWith('/resolved/skills/memori/skills.md', 'utf-8');
+    expect(mockResolvePath).toHaveBeenCalledWith('skills/memori/SKILL.md');
+    expect(readFileSync).toHaveBeenCalledWith('/resolved/skills/memori/SKILL.md', 'utf-8');
   });
 
   it('should return the file contents when the file exists', async () => {


### PR DESCRIPTION
- Remove the 'limit' parameter from the memori-recall tool schema and calls. 
- Tests were updated to remove expectations and arguments referencing 'limit' and to match the new tool signature.
- Additionally, the skills-loader test was updated to expect 'SKILL.md' (instead of 'skills.md') and the mockResolvePath was given a concrete (input: string) => string type. These updates align tests with the updated tool API and filename conventions.