### PR TITLE
Bump @memorilabs/openclaw-memori to 0.0.11

### DIFF
--- a/integrations/openclaw/package-lock.json
+++ b/integrations/openclaw/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memorilabs/openclaw-memori",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorilabs/openclaw-memori",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@memorilabs/memori": "0.1.12-beta"

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorilabs/openclaw-memori",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Official MemoriLabs.ai long-term memory plugin for OpenClaw",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Update package.json and package-lock.json to bump the @memorilabs/openclaw-memori package version from 0.0.10 to 0.0.11, keeping the lockfile in sync with the manifest for the OpenClaw integration.