### PR TITLE
Fix Rust TS Android Build Error

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -219,6 +219,7 @@ jobs:
           - os: macos-15-intel
             artifact-name: darwin-x64
             rust-target: x86_64-apple-darwin
+            cargo-args: --no-default-features --features ort-load-dynamic
           - os: windows-latest
             artifact-name: win32-x64-msvc
             rust-target: x86_64-pc-windows-msvc

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -225,6 +225,7 @@ jobs:
           - os: ubuntu-latest
             artifact-name: android-arm64
             rust-target: aarch64-linux-android
+            cargo-args: --no-default-features --features ort-load-dynamic
     steps:
       - uses: actions/checkout@v5
 
@@ -282,4 +283,4 @@ jobs:
 
       - name: Build Rust bindings
         working-directory: ./core/bindings/node
-        run: npm run build -- --target ${{ matrix.rust-target }}
+        run: npm run build -- --target ${{ matrix.rust-target }} ${{ matrix.cargo-args || '' }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -28,6 +28,7 @@ jobs:
           - os: macos-15-intel
             artifact-name: darwin-x64
             rust-target: x86_64-apple-darwin
+            cargo-args: --no-default-features --features ort-load-dynamic
           - os: windows-latest
             artifact-name: win32-x64-msvc
             rust-target: x86_64-pc-windows-msvc

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -34,6 +34,7 @@ jobs:
           - os: ubuntu-latest
             artifact-name: android-arm64
             rust-target: aarch64-linux-android
+            cargo-args: --no-default-features --features ort-load-dynamic
 
     steps:
       - name: Checkout repository
@@ -95,7 +96,7 @@ jobs:
 
       - name: Build Rust bindings
         working-directory: ./core/bindings/node
-        run: npm run build -- --target ${{ matrix.rust-target }}
+        run: npm run build -- --target ${{ matrix.rust-target }} ${{ matrix.cargo-args || '' }}
 
       - name: Upload native artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ts-ci.yml
+++ b/.github/workflows/ts-ci.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install NAPI build dependencies
         working-directory: ./core/bindings/node
-        run: npm install
+        run: npm ci
 
       - name: Set Windows C/C++ dynamic CRT flags
         if: runner.os == 'Windows'

--- a/core/bindings/node/Cargo.toml
+++ b/core/bindings/node/Cargo.toml
@@ -5,12 +5,17 @@ version.workspace = true
 license.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["ort-download-binaries"]
+ort-download-binaries = ["engine-orchestrator/ort-download-binaries"]
+ort-load-dynamic = ["engine-orchestrator/ort-load-dynamic"]
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 dashmap = "6.1.0"
-engine-orchestrator = { path = "../..", default-features = false, features = ["ort-load-dynamic"] }
+engine-orchestrator = { path = "../..", default-features = false }
 napi = { workspace = true, features = ["napi8", "tokio_rt", "async"] }
 napi-derive.workspace = true
 serde = { version = "1.0.228", features = ["derive"] }

--- a/memori-ts/package-lock.json
+++ b/memori-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memorilabs/memori",
-  "version": "0.1.12-beta",
+  "version": "0.1.13-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorilabs/memori",
-      "version": "0.1.12-beta",
+      "version": "0.1.13-beta",
       "license": "Apache-2.0",
       "dependencies": {
         "@memorilabs/axon": "^0.1.5"

--- a/memori-ts/package.json
+++ b/memori-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorilabs/memori",
-  "version": "0.1.12-beta",
+  "version": "0.1.13-beta",
   "description": "The official TypeScript SDK for Memori",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
- The Android support commit hardcoded `ort-load-dynamic` in `node-bindings/Cargo.toml`, which broke embedding on all non-Android platforms. The .node binary no longer had a link-time dependency on libonnxruntime.dylib, so ort's runtime dlopen call failed at startup.

- Adds a [features] block to node-bindings so ort-download-binaries is the default (restoring previous behavior) and ort-load-dynamic is opt-in for Android. CI passes --no-default-features --features ort-load-dynamic only for the Android matrix entries.

- bump version numbers