### PR TITLE
fix(node-bindings): gracefully release N-API event loop references on…

### DIFF
--- a/core/bindings/node/src/bridge.rs
+++ b/core/bindings/node/src/bridge.rs
@@ -5,6 +5,7 @@ use engine_orchestrator::storage::{
 };
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 use tokio::sync::oneshot;
@@ -17,9 +18,9 @@ pub type PendingFactsMap = Arc<DashMap<u32, oneshot::Sender<Vec<CandidateFactRow
 pub type PendingWritesMap = Arc<DashMap<u32, oneshot::Sender<WriteAck>>>;
 
 pub struct NodeStorageBridge {
-    pub fetch_embeddings_tsfn: ThreadsafeFunction<(u32, String)>,
-    pub fetch_facts_by_ids_tsfn: ThreadsafeFunction<(u32, String)>,
-    pub write_batch_tsfn: ThreadsafeFunction<(u32, String)>,
+    pub fetch_embeddings_tsfn: Mutex<Option<ThreadsafeFunction<(u32, String)>>>,
+    pub fetch_facts_by_ids_tsfn: Mutex<Option<ThreadsafeFunction<(u32, String)>>>,
+    pub write_batch_tsfn: Mutex<Option<ThreadsafeFunction<(u32, String)>>>,
     pub pending_embeddings: PendingEmbeddingsMap,
     pub pending_facts: PendingFactsMap,
     pub pending_writes: PendingWritesMap,
@@ -38,9 +39,13 @@ impl StorageBridge for NodeStorageBridge {
 
         self.pending_embeddings.insert(id, tx);
 
-        let status = self
-            .fetch_embeddings_tsfn
-            .call(Ok((id, payload)), ThreadsafeFunctionCallMode::NonBlocking);
+        let status = {
+            if let Some(tsfn) = self.fetch_embeddings_tsfn.lock().unwrap().as_ref() {
+                tsfn.call(Ok((id, payload)), ThreadsafeFunctionCallMode::NonBlocking)
+            } else {
+                napi::Status::Closing
+            }
+        };
 
         // Fail gracefully if the TS function queue fails, preventing thread lockup
         if status != napi::Status::Ok {
@@ -75,9 +80,13 @@ impl StorageBridge for NodeStorageBridge {
 
         self.pending_facts.insert(id, tx);
 
-        let status = self
-            .fetch_facts_by_ids_tsfn
-            .call(Ok((id, payload)), ThreadsafeFunctionCallMode::NonBlocking);
+        let status = {
+            if let Some(tsfn) = self.fetch_facts_by_ids_tsfn.lock().unwrap().as_ref() {
+                tsfn.call(Ok((id, payload)), ThreadsafeFunctionCallMode::NonBlocking)
+            } else {
+                napi::Status::Closing
+            }
+        };
 
         if status != napi::Status::Ok {
             self.pending_facts.remove(&id);
@@ -109,9 +118,13 @@ impl StorageBridge for NodeStorageBridge {
 
         self.pending_writes.insert(id, tx);
 
-        let status = self
-            .write_batch_tsfn
-            .call(Ok((id, payload)), ThreadsafeFunctionCallMode::NonBlocking);
+        let status = {
+            if let Some(tsfn) = self.write_batch_tsfn.lock().unwrap().as_ref() {
+                tsfn.call(Ok((id, payload)), ThreadsafeFunctionCallMode::NonBlocking)
+            } else {
+                napi::Status::Closing
+            }
+        };
 
         if status != napi::Status::Ok {
             self.pending_writes.remove(&id);
@@ -133,5 +146,14 @@ impl StorageBridge for NodeStorageBridge {
                 }
             })
         })
+    }
+
+    fn shutdown(&self) {
+        // .take() pulls the ThreadsafeFunction out of the Option.
+        // Because we don't keep it, Rust immediately drops it.
+        // The Drop implementation automatically releases the Node.js event loop reference!
+        let _ = self.fetch_embeddings_tsfn.lock().unwrap().take();
+        let _ = self.fetch_facts_by_ids_tsfn.lock().unwrap().take();
+        let _ = self.write_batch_tsfn.lock().unwrap().take();
     }
 }

--- a/core/bindings/node/src/bridge.rs
+++ b/core/bindings/node/src/bridge.rs
@@ -149,9 +149,6 @@ impl StorageBridge for NodeStorageBridge {
     }
 
     fn shutdown(&self) {
-        // .take() pulls the ThreadsafeFunction out of the Option.
-        // Because we don't keep it, Rust immediately drops it.
-        // The Drop implementation automatically releases the Node.js event loop reference!
         let _ = self.fetch_embeddings_tsfn.lock().unwrap().take();
         let _ = self.fetch_facts_by_ids_tsfn.lock().unwrap().take();
         let _ = self.write_batch_tsfn.lock().unwrap().take();

--- a/core/bindings/node/src/engine.rs
+++ b/core/bindings/node/src/engine.rs
@@ -8,8 +8,8 @@ use napi::bindgen_prelude::*;
 use napi::threadsafe_function::ThreadsafeFunction;
 use napi_derive::napi;
 use std::panic::catch_unwind;
-use std::sync::Arc;
 use std::sync::atomic::AtomicU32;
+use std::sync::{Arc, Mutex};
 
 #[napi]
 pub struct MemoriEngine {
@@ -33,9 +33,9 @@ impl MemoriEngine {
         let pending_writes = Arc::new(DashMap::new());
 
         let bridge = Arc::new(NodeStorageBridge {
-            fetch_embeddings_tsfn: fetch_embeddings_cb,
-            fetch_facts_by_ids_tsfn: fetch_facts_by_ids_cb,
-            write_batch_tsfn: write_batch_cb,
+            fetch_embeddings_tsfn: Mutex::new(Some(fetch_embeddings_cb)),
+            fetch_facts_by_ids_tsfn: Mutex::new(Some(fetch_facts_by_ids_cb)),
+            write_batch_tsfn: Mutex::new(Some(write_batch_cb)),
             pending_embeddings: pending_embeddings.clone(),
             pending_facts: pending_facts.clone(),
             pending_writes: pending_writes.clone(),

--- a/core/src/storage/bridge.rs
+++ b/core/src/storage/bridge.rs
@@ -14,4 +14,6 @@ pub trait StorageBridge: Send + Sync {
     -> Result<Vec<CandidateFactRow>, HostStorageError>;
 
     fn write_batch(&self, batch: &WriteBatch) -> Result<WriteAck, HostStorageError>;
+
+    fn shutdown(&self) {}
 }

--- a/memori-ts/package-lock.json
+++ b/memori-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memorilabs/memori",
-  "version": "0.1.13-beta",
+  "version": "0.1.14-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorilabs/memori",
-      "version": "0.1.13-beta",
+      "version": "0.1.14-beta",
       "license": "Apache-2.0",
       "dependencies": {
         "@memorilabs/axon": "^0.1.5"

--- a/memori-ts/package.json
+++ b/memori-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorilabs/memori",
-  "version": "0.1.13-beta",
+  "version": "0.1.14-beta",
   "description": "The official TypeScript SDK for Memori",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
**Context & Problem**
Previously, Node.js scripts (including our test suite) would hang indefinitely after finishing execution and required a manual `Ctrl+C` to exit. This was caused by the `napi-rs` `ThreadsafeFunction` objects (`fetch_embeddings_cb`, `fetch_facts_by_ids_cb`, `write_batch_cb`) in the `NodeStorageBridge`. These objects hold active references on the Node.js event loop to listen for background Rust tasks, preventing the V8 engine from exiting even after `memori.engine = undefined` was set.

**Changes in this PR**
* **Core StorageBridge:** Added a `shutdown(&self) {}` default method to the `StorageBridge` trait in the core engine.
* **Node Storage Bridge:** * Wrapped the N-API `ThreadsafeFunction` callbacks in `Mutex<Option<...>>` to allow safe ownership transfer.
  * Implemented `shutdown` on `NodeStorageBridge` to `.take()` the callbacks out of the struct. By removing them from the struct, Rust automatically invokes `Drop`, which gracefully signals Node.js to release the event loop references.
* **Python Bindings:** No changes required. Because the new `shutdown` trait method has a default empty implementation, the existing Python bridge inherits a safe no-op, guaranteeing zero breaking changes to the Python SDK.

**Impact**
Calling `memori.config.storage.close()` or `memori.engine.shutdown()` in Node.js will now successfully abort the Rust background queues and instantly drop the event loop references, allowing short-lived scripts and test runners to exit cleanly.