### PR TITLE
Update version and description for hermes-memori integration

### DIFF
--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -1,7 +1,5 @@
 # Memori for Hermes Agent
 
-Official Memori Labs provider for Hermes Agent, enabling structured long-term memory from agent trace and execution.
-
 Memori gives Hermes Agent structured, long-term memory from agent trace and execution. It captures completed agent activity — including user goals, assistant decisions, tool usage, workflow steps, outcomes, constraints, failures, and feedback — and structures that activity into durable memory primitives for future recall. This allows Hermes agents to learn from prior execution, preserve workflow context, avoid repeated mistakes, and become more efficient over time. The provider exposes explicit tools for memory recall, summaries, quota checks, signup, and feedback.
 
 ## Requirements

--- a/integrations/hermes/pyproject.toml
+++ b/integrations/hermes/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-memori"
-version = "0.1.1"
-description = "Official Memori Labs long-term memory provider for Hermes Agent"
+version = "0.1.2"
+description = "Official Memori Labs provider for Hermes Agent, enabling structured long-term memory from agent trace and execution."
 authors = [{name = "Memori Labs Team", email = "noc@memorilabs.ai"}]
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
- Bump version from 0.1.1 to 0.1.2 in `pyproject.toml`.
- Refine project description to better reflect the capabilities of the Memori integration for Hermes Agent in the README.