### PR TITLE
fix: accept string IDs at the Rust/TS boundary for BYODB BigInt

### DIFF
--- a/core/bindings/node/src/engine.rs
+++ b/core/bindings/node/src/engine.rs
@@ -3,7 +3,7 @@ use crate::types::*;
 use dashmap::DashMap;
 use engine_orchestrator::EngineOrchestrator;
 use engine_orchestrator::search::FactId;
-use engine_orchestrator::storage::{CandidateFactRow, EmbeddingRow, WriteAck};
+use engine_orchestrator::storage::{CandidateFactRow, EmbeddingRow, RankedFact, WriteAck};
 use napi::bindgen_prelude::*;
 use napi::threadsafe_function::ThreadsafeFunction;
 use napi_derive::napi;
@@ -138,12 +138,44 @@ impl MemoriEngine {
         tokio::task::spawn_blocking(move || {
             let req = serde_json::from_value(serde_json::to_value(&request).unwrap())
                 .map_err(|e| Error::from_reason(format!("Invalid retrieval request: {}", e)))?;
-            let results = inner
+            let results: Vec<RankedFact> = inner
                 .retrieve(req)
                 .map_err(|e| Error::from_reason(e.to_string()))?;
-            let napi_results: Vec<NapiRecallObject> =
-                serde_json::from_value(serde_json::to_value(&results).unwrap())
-                    .map_err(|e| Error::from_reason(e.to_string()))?;
+            let napi_results = results
+                .into_iter()
+                .map(|r| {
+                    let id = match r.id {
+                        FactId::Int(n) => Either::A(n),
+                        FactId::String(s) => Either::B(s),
+                    };
+                    let summaries = if r.summaries.is_empty() {
+                        None
+                    } else {
+                        Some(
+                            r.summaries
+                                .into_iter()
+                                .map(|s| NapiRecallSummary {
+                                    content: s["content"].as_str().unwrap_or("").to_string(),
+                                    date_created: s["date_created"]
+                                        .as_str()
+                                        .unwrap_or("")
+                                        .to_string(),
+                                    entity_fact_id: fact_id_from_json(&s["entity_fact_id"]),
+                                    fact_id: fact_id_from_json(&s["fact_id"]),
+                                })
+                                .collect(),
+                        )
+                    };
+                    NapiRecallObject {
+                        id,
+                        content: r.content,
+                        rank_score: Some(r.rank_score as f64),
+                        similarity: Some(r.similarity as f64),
+                        date_created: Some(r.date_created),
+                        summaries,
+                    }
+                })
+                .collect();
             Ok(napi_results)
         })
         .await
@@ -198,5 +230,13 @@ impl MemoriEngine {
     #[napi]
     pub fn shutdown(&self) {
         self.inner.shutdown();
+    }
+}
+
+fn fact_id_from_json(v: &serde_json::Value) -> Option<Either<i64, String>> {
+    match v {
+        serde_json::Value::Number(n) => n.as_i64().map(Either::A),
+        serde_json::Value::String(s) => Some(Either::B(s.clone())),
+        _ => None,
     }
 }

--- a/core/bindings/node/src/types.rs
+++ b/core/bindings/node/src/types.rs
@@ -15,18 +15,16 @@ pub struct NapiRetrievalRequest {
 }
 
 #[napi(object)]
-#[derive(Serialize, Deserialize)]
 pub struct NapiRecallSummary {
     pub content: String,
     pub date_created: String,
-    pub entity_fact_id: Option<i64>,
-    pub fact_id: Option<i64>,
+    pub entity_fact_id: Option<Either<i64, String>>,
+    pub fact_id: Option<Either<i64, String>>,
 }
 
 #[napi(object)]
-#[derive(Serialize, Deserialize)]
 pub struct NapiRecallObject {
-    pub id: i64,
+    pub id: Either<i64, String>,
     pub content: String,
     pub rank_score: Option<f64>,
     pub similarity: Option<f64>,

--- a/memori-ts/package-lock.json
+++ b/memori-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memorilabs/memori",
-  "version": "0.1.16-beta",
+  "version": "0.1.17-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorilabs/memori",
-      "version": "0.1.16-beta",
+      "version": "0.1.17-beta",
       "license": "Apache-2.0",
       "dependencies": {
         "@memorilabs/axon": "^0.1.5"

--- a/memori-ts/package.json
+++ b/memori-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorilabs/memori",
-  "version": "0.1.16-beta",
+  "version": "0.1.17-beta",
   "description": "The official TypeScript SDK for Memori",
   "type": "module",
   "main": "./dist/index.js",

--- a/memori-ts/src/core/engine.ts
+++ b/memori-ts/src/core/engine.ts
@@ -184,8 +184,8 @@ export class NativeEngine {
       summaries: r.summaries?.map((s) => ({
         content: s.content,
         date_created: s.dateCreated,
-        entity_fact_id: s.entityFactId as number,
-        fact_id: s.factId as number,
+        entity_fact_id: s.entityFactId as number | string,
+        fact_id: s.factId as number | string,
       })),
     }));
   }

--- a/memori-ts/src/native/index.d.ts
+++ b/memori-ts/src/native/index.d.ts
@@ -61,7 +61,7 @@ export interface NapiMessage {
 }
 
 export interface NapiRecallObject {
-  id: number;
+  id: number | string;
   content: string;
   rankScore?: number;
   similarity?: number;
@@ -72,8 +72,8 @@ export interface NapiRecallObject {
 export interface NapiRecallSummary {
   content: string;
   dateCreated: string;
-  entityFactId?: number;
-  factId?: number;
+  entityFactId?: number | string;
+  factId?: number | string;
 }
 
 export interface NapiRetrievalRequest {

--- a/memori-ts/src/types/api.ts
+++ b/memori-ts/src/types/api.ts
@@ -14,7 +14,7 @@ export interface RetrievalRequest {
  * @internal
  */
 export interface RecallObject {
-  id: number;
+  id: number | string;
   content: string;
   rank_score?: number;
   similarity?: number;
@@ -26,7 +26,7 @@ export interface RecallObject {
  * Single row from the native N-API `retrieve` response (camelCase before mapping to `RecallObject`).
  */
 export interface NapiRecallRow {
-  id: number;
+  id: number | string;
   content: string;
   rankScore?: number;
   similarity?: number;
@@ -34,8 +34,8 @@ export interface NapiRecallRow {
   summaries?: Array<{
     content: string;
     dateCreated: string;
-    entityFactId?: number;
-    factId?: number;
+    entityFactId?: number | string;
+    factId?: number | string;
   }>;
 }
 
@@ -51,8 +51,8 @@ export type RecallItem = string | RecallObject;
 export interface RecallSummary {
   content: string;
   date_created: string;
-  entity_fact_id: number;
-  fact_id: number;
+  entity_fact_id: number | string;
+  fact_id: number | string;
 }
 
 /**

--- a/memori-ts/src/utils/utils.ts
+++ b/memori-ts/src/utils/utils.ts
@@ -51,7 +51,7 @@ export function formatSummariesFromFacts(facts: ParsedFact[]): string[] {
 function attachRawSummariesToFacts(facts: RecallItem[], summaries: RecallSummary[]): RecallItem[] {
   if (summaries.length === 0) return facts;
 
-  const summariesByFactId = new Map<number, RecallSummary[]>();
+  const summariesByFactId = new Map<number | string, RecallSummary[]>();
 
   for (const summary of summaries) {
     const summaryFactId = summary.entity_fact_id;


### PR DESCRIPTION
## Problem

CockroachDB uses `BIGINT` primary keys that exceed JavaScript's `Number.MAX_SAFE_INTEGER`
(e.g. `1172888091194032000`). Our PostgreSQL/CockroachDB storage drivers were recently fixed
to return these IDs as strings instead of casting them to `Number`, which silently lost
precision.

However, the Rust N-API boundary hadn't been updated to match. When the TypeScript SDK passed
a stringified ID back through the `retrieve` path, serde tried to deserialize the JSON string
`"1172888091194032000"` into a strict `i64` field and panicked:

[Error: invalid type: string "1", expected i64]



## Solution

Widen the ID types at every layer of the stack — Rust structs, TypeScript interfaces, and the
`index.d.ts` declaration — so the engine acts as a universal pass-through that accepts both
integer IDs (SQLite, MySQL) and string IDs (PostgreSQL, CockroachDB).

### Rust (`core/bindings/node/src/`)

**`types.rs`** — `NapiRecallObject` and `NapiRecallSummary`:
- `id: i64` → `id: Either<i64, String>`, consistent with the existing pattern already used by
  `NapiEmbeddingRow` and `NapiCandidateFactRow`
- `entity_fact_id` / `fact_id`: `Option<i64>` → `Option<Either<i64, String>>`
- Dropped `#[derive(Serialize, Deserialize)]` from both structs since they no longer go through
  a serde round-trip

**`engine.rs`** — `retrieve` method:
- Replaced the lossy `serde_json::to_value(&results)` → `serde_json::from_value(...)` round-trip
  with a direct `into_iter().map(...)` that explicitly matches `FactId::Int(n) → Either::A(n)`
  and `FactId::String(s) → Either::B(s)`
- Added a `fact_id_from_json` helper to safely extract `Option<Either<i64, String>>` from the
  opaque `serde_json::Value` summary blobs
- Added `RankedFact` to the storage import

### TypeScript (`memori-ts/src/`)

**`types/api.ts`** — `RecallObject`, `NapiRecallRow`, `RecallSummary`:
- `id`, `entity_fact_id`, `fact_id`, `entityFactId`, `factId` widened from `number` to
  `number | string`

**`core/engine.ts`**:
- Updated stale `as number` casts on `s.entityFactId` / `s.factId` to `as number | string`

**`native/index.d.ts`** (auto-generated, updated ahead of next `napi build`):
- `NapiRecallObject.id` and `NapiRecallSummary.entityFactId` / `factId` widened to
  `number | string`

**`utils/utils.ts`**:
- `Map<number, RecallSummary[]>` → `Map<number | string, RecallSummary[]>` in the cloud-path
  summary grouping function

## Compatibility

- **SQLite / MySQL** — integer IDs still flow through as `Either::A(i64)` / `number`. No
  behavior change.
- **PostgreSQL / CockroachDB** — string IDs now flow through as `Either::B(String)` / `string`
  without truncation or panic.
- No public API surface change; `id` accepting `number | string` is a non-breaking widening for
  all callers.