### PR TITLE
Revise readme so Python SDK sections are open by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </p>
 <p align="center">
   <a href="https://trendshift.io/repositories/15418">
-    <img src="https://trendshift.io/_next/image?url=https%3A%2F%2Ftrendshift.io%2Fapi%2Fbadge%2Frepositories%2F15418&w=640&q=75" alt="Memori%2fLabs%2FMemori | Trendshif">
+    <img src="https://trendshift.io/_next/image?url=https%3A%2F%2Ftrendshift.io%2Fapi%2Fbadge%2Frepositories%2F15418&w=640&q=75" alt="Memori%2fLabs%2FMemori | Trendshift">
   </a>
 </p>
 
@@ -63,7 +63,7 @@ npm install @memorilabs/memori
 ```
 </details>
 
-<details>
+<details open>
 <summary><b>Python SDK</b></summary>
 
 ```bash
@@ -106,7 +106,7 @@ async function main() {
 ```
 </details>
 
-<details>
+<details open>
 <summary><b>Python SDK</b></summary>
 
 ```python
@@ -153,16 +153,18 @@ Read the [benchmark overview](docs/memori-cloud/benchmark/overview.mdx), see the
 
 ## OpenClaw (Persistent Memory for Your Gateway)
 
-By default, OpenClaw agents forget everything between sessions. The Memori plugin fixes that. It captures durable facts and preferences after each conversation, then injects the most relevant context back into future prompts automatically.
+By default, OpenClaw agents forget everything between sessions. The Memori plugin fixes that. It automatically captures structured memory from conversation and agent execution after each turn — including tool calls, decisions, and outcomes — and makes it available for agents to recall on demand.
 
-No changes to your agent code or prompts are required. The plugin hooks into OpenClaw's lifecycle, so you get structured memory, Intelligent Recall, and Advanced Augmentation with a drop-in plugin.
+No changes to your agent code or prompts are required. The plugin hooks into OpenClaw's lifecycle, so you get structured memory, agent-controlled recall, and Advanced Augmentation with a drop-in plugin.
 
 ```bash
 openclaw plugins install @memorilabs/openclaw-memori
 openclaw plugins enable openclaw-memori
 
-openclaw config set plugins.entries.openclaw-memori.config.apiKey "YOUR_MEMORI_API_KEY"
-openclaw config set plugins.entries.openclaw-memori.config.entityId "your-app-user-id"
+openclaw memori init \
+  --api-key "YOUR_MEMORI_API_KEY" \
+  --entity-id "your-app-user-id" \
+  --project-id "my-project"
 
 openclaw gateway restart
 ```
@@ -200,7 +202,7 @@ mem.attribution("12345", "my-ai-bot");
 ```
 </details>
 
-<details>
+<details open>
 <summary><b>Python SDK</b></summary>
 
 ```python
@@ -224,7 +226,7 @@ mem.setSession(sessionId);
 ```
 </details>
 
-<details>
+<details open>
 <summary><b>Python SDK</b></summary>
 
 ```python

--- a/docs/memori-byodb/concepts/agent-trace-execution.mdx
+++ b/docs/memori-byodb/concepts/agent-trace-execution.mdx
@@ -17,14 +17,14 @@ As your agent works, Memori captures the full conversation including tool calls,
 
 Memori stores execution knowledge in two complementary forms:
 
-- **Structured memory** — facts, decisions, and constraints used for targeted retrieval and reasoning
+- **Structured memory primitives** — precise, queryable records of facts, decisions, constraints, actions, tool results, and outcomes used for targeted retrieval and reasoning
 - **Rolling summaries** — continuously updated context used for grounding and situational awareness
 
-### Grounded in actions, not just text
+### Grounded in agent execution, not just text
 
-Memori captures tool calls and execution traces alongside conversation data. Memory reflects what actually happened — not just what was discussed.
+Memori incorporates tool calls and execution traces alongside conversation data. This means memory reflects not just what was discussed, but what the agent actually did and what results those actions produced.
 
-By grounding memory in actions and outcomes, the system produces more reliable, verifiable, and actionable context.
+By structuring memory from actions, tool results, decisions, and outcomes, the system gives the agent a fuller understanding of prior task execution so the next time it acts, it can be more accurate and efficient.
 
 ## Context Recall
 
@@ -43,9 +43,3 @@ When a query is sent to an LLM through a wrapped client, Memori automatically in
 - Use cases where agent behavior should improve over time
 - Debugging and auditing agent decisions across sessions
 - Building relationships between actions, tools, and outcomes
-
-<Admonition type="important" title="Attribution is Required">
-  For Memori to capture and recall agent execution memory, attribution must be
-  set before recording trace events. Without attribution, Memori cannot scope or
-  retrieve execution memories.
-</Admonition>

--- a/docs/memori-cloud/concepts/agent-trace-execution.mdx
+++ b/docs/memori-cloud/concepts/agent-trace-execution.mdx
@@ -17,27 +17,11 @@ As your agent works, Memori captures the full conversation including tool calls,
 
 Memori stores execution knowledge in two complementary forms:
 
-- **Structured memory** — facts, decisions, and constraints used for targeted retrieval and reasoning
+- **Structured memory primitives** — precise, queryable records of facts, decisions, constraints, actions, tool results, and outcomes used for targeted retrieval and reasoning
 - **Rolling summaries** — continuously updated context used for grounding and situational awareness
 
-### Grounded in actions, not just text
+### Grounded in agent execution, not just text
 
-Memori captures tool calls and execution traces alongside conversation data. Memory reflects what actually happened — not just what was discussed.
+Memori incorporates tool calls and execution traces alongside conversation data. This means memory reflects not just what was discussed, but what the agent actually did and what results those actions produced.
 
-By grounding memory in actions and outcomes, the system produces more reliable, verifiable, and actionable context.
-
-## Context Recall
-
-When a query is sent to an LLM through a wrapped client, Memori automatically includes relevant execution history:
-
-1. Intercepts the outbound LLM call
-2. Uses semantic search to find execution facts matching the query
-3. Ranks facts by vector similarity
-4. Injects the most relevant execution context into the system prompt
-5. Forwards the enriched request to the LLM provider
-
-<Admonition type="important" title="Attribution is Required">
-  For Memori to capture and recall agent execution memory, attribution must be
-  set before recording trace events. Without attribution, Memori cannot scope or
-  retrieve execution memories.
-</Admonition>
+By structuring memory from actions, tool results, decisions, and outcomes, the system gives the agent a fuller understanding of prior task execution so the next time it acts, it can be more accurate and efficient.

--- a/docs/memori-cloud/openclaw/overview.mdx
+++ b/docs/memori-cloud/openclaw/overview.mdx
@@ -7,7 +7,7 @@ description: Give your OpenClaw agents structured, persistent memory with the Me
 
 Memori gives OpenClaw agents a structured, long-term memory system. It automatically captures what happens and lets agents recall it on demand — so context survives across sessions without bloating the prompt.
 
-Instead of replaying transcripts or relying on lossy summaries, Memori builds a persistent **experience layer** that agents can query when it matters.
+Instead of relying solely on natural-language memory, Memori structures persistent memory from both conversation and agent trace — the agent's actions, tool results, decisions, and outcomes — so it can recall what actually happened when it matters.
 
 ---
 
@@ -46,11 +46,11 @@ Memories are organized using four core identifiers:
 
 ## Core Capabilities
 
-### 1. Memory generation and experience layer
+### 1. Structured memory from conversation and agent trace
 
-Memori transforms raw agent sessions (messages + traces) into structured memory and a continuously updated summary.
+Memori transforms raw agent sessions (messages + traces) into structured memory primitives and continuously updated summaries.
 
-Instead of replaying full transcripts, it builds a compact, reusable **experience layer** that allows agents to maintain continuity across long-running interactions.
+Instead of replaying full transcripts, Memori turns conversation and agent execution into structured memory that preserves what the agent did, what happened, and what it learned across long-running interactions.
 
 The system focuses on extracting what matters:
 
@@ -65,29 +65,30 @@ Rather than preserving every detail, Memori prioritizes signal over noise — ke
 
 Memori stores knowledge in two complementary forms:
 
-- **Structured, typed memory** — precise, queryable records (facts, decisions, constraints, etc.) used for targeted retrieval and reasoning
+- **Structured memory primitives** — precise, queryable records of facts, decisions, constraints, actions, tool results, and outcomes used for targeted retrieval and reasoning
 - **Rolling summaries** — continuously updated context used for grounding and situational awareness
 
 Structured memory is stored in a knowledge graph, enabling relationships, deduplication, and precise retrieval.
 
-#### Grounded in actions, not just text
+#### Grounded in agent execution, not just text
 
-Memori incorporates tool calls and execution traces alongside conversation data. This means memory reflects what actually happened — not just what was discussed.
+Memori incorporates tool calls and execution traces alongside conversation data. This means memory reflects not just what was discussed, but what the agent actually did and what results those actions produced.
 
-By grounding memory in actions and outcomes, the system produces more reliable, verifiable, and actionable context.
+By structuring memory from actions, tool results, decisions, and outcomes, the system gives the agent a fuller understanding of prior task execution so the next time it acts, it can be more accurate and efficient.
 
 ---
 
 ### 2. Advanced Augmentation (automatic)
 
-After each interaction, Memori processes the conversation asynchronously.
+After each interaction, Memori converts raw session data into structured, reusable memories asynchronously.
 
-- Extracts facts, preferences, and attributes
-- Classifies memory types
+- Transforms raw agent sessions into structured memory units
+- Captures the agent's actions, reasoning, tool usage, responses, corrections, and failures
+- Organizes into classes to enable efficient retrieval
 - Generates embeddings for semantic retrieval
 - Updates structured memory and the knowledge graph
 
-This is how the experience layer is continuously built and updated over time.
+This is how structured memory is continuously built and updated over time.
 
 It runs **after the agent responds** and does not impact latency.
 
@@ -97,9 +98,9 @@ It runs **after the agent responds** and does not impact latency.
 
 Recall is **explicit and initiated by the agent**.
 
-Memori separates memory capture from memory usage:
+Memori separates memory creation from memory recall:
 
-- Capture is automatic (advanced augmentation)
+- Creation is automatic (advanced augmentation)
 - Recall is intentional (agent-controlled)
 
 Agents decide:

--- a/docs/memori-cloud/openclaw/quickstart.mdx
+++ b/docs/memori-cloud/openclaw/quickstart.mdx
@@ -123,11 +123,11 @@ The Memori plugin operates on two parallel tracks:
 | Track | Mechanism | What it does |
 | --- | --- | --- |
 | **Agent-Controlled Recall** | Plugin Tools | Equips the agent with `memori_recall`, `memori_recall_summary`, and `memori_feedback`. The agent retrieves memory explicitly when needed. |
-| **Advanced Augmentation** | `agent_end` Hook | After the agent responds, the exchange is sanitized and sent to Memori in the background to update structured memory and the knowledge graph. |
+| **Advanced Augmentation** | `agent_end` Hook | After the agent responds, the exchange and execution trace are sanitized and sent to Memori in the background to structure memory from conversation, tool activity, decisions, and outcomes. |
 
-Together, these systems continuously build and maintain an **experience layer** — a structured, reusable representation of what has happened over time that agents can query on demand.
+Together, these systems continuously structure memory from not just natural language, but also from agent trace and execution. Memori captures the agent's actions, tool results, decisions, and outcomes into durable memory the agent can recall on demand — so the next time it performs a task, it is more accurate and efficient.
 
-Memori does not automatically inject memory into the prompt. Instead, agents retrieve only the context they need, improving accuracy while avoiding unnecessary token usage.
+Memori does not automatically inject memory into the prompt. Instead, agents retrieve only the context they need, improving accuracy and efficiency while avoiding unnecessary token usage.
 
 <Admonition type="tip" title="Multi-Agent Gateways">
   The plugin is fully stateless and thread-safe. You can run it across multiple agents in the same gateway without any shared state or concurrency issues.


### PR DESCRIPTION
## Summary

- All Python SDK `<details>` sections now open by default, matching TypeScript SDK
- Fixed Trendshift typo in alt text
- Revised OpenClaw description to reflect agent controlled recall
- Revised OpenClaw setup commands to use `openclaw memori init` with `--api-key`, `--entity-id`, `--project-id`, and `openclaw gateway restart`

## Type of Change

- [x] Bug fix (outdated info)
- [x] Content improvement

## Checklist

- [x] Content is up to date
- [x] Spelling and grammar checked