### PR TITLE
Revise OpenClaw docs to say Agent-Controlled Intelligent Recall

### DIFF
--- a/docs/memori-cloud/openclaw/overview.mdx
+++ b/docs/memori-cloud/openclaw/overview.mdx
@@ -94,7 +94,7 @@ It runs **after the agent responds** and does not impact latency.
 
 ---
 
-### 3. Agent-controlled recall
+### 3. Agent-Controlled Intelligent Recall
 
 Recall is **explicit and initiated by the agent**.
 
@@ -109,6 +109,20 @@ Agents decide:
 - What scope to recall from
 - How much history to include
 
+Recall is also intelligent. When memories are retrieved, Memori does not simply return raw chronological history. It uses a proprietary multi-dimensional ranking algorithm to prioritize the memories most likely to matter for the current agent task.
+
+The recall algorithm takes into account factors such as:
+
+- Source and signal weights
+- Recency
+- Frequency
+- Memory type
+- Scope relevance
+- Historical importance
+- Retrieval context
+
+This allows agents to retrieve the most relevant facts, decisions, constraints, patterns, and prior outcomes without stuffing irrelevant history into the prompt.
+
 Supported parameters:
 
 - `entity_id`
@@ -119,7 +133,7 @@ Supported parameters:
 - `source`
 - `signal`
 
-#### Memory classification schema
+#### Memory classification schema:
 
 **Sources**
 - constraint
@@ -142,7 +156,7 @@ Supported parameters:
 - update
 - verification
 
-#### Default behavior
+#### Default behavior:
 
 - If no date range is provided → returns **all-time**
 
@@ -153,6 +167,8 @@ Supported parameters:
 - Constraints
 - Patterns
 - Summaries
+- Execution outcomes
+- Known failure modes
 
 ---
 
@@ -164,7 +180,7 @@ These summaries are generated from structured memory and execution traces — no
 
 They represent the agent's **working state**, not just a recap.
 
-#### Daily brief structure
+#### Daily brief structure:
 
 Memori generates a consistent, structured daily brief with the following sections:
 
@@ -193,7 +209,7 @@ Supported parameters:
 - `date_start`
 - `date_end`
 
-#### Default behavior
+#### Default behavior:
 
 - If no date range is provided → returns **last 24 hours**
 
@@ -217,7 +233,7 @@ Memori Cloud provides full visibility into memory behavior:
 Memori separates memory into two systems:
 
 - **Advanced Augmentation (automatic)** — captures and structures memory
-- **Agent-controlled recall (on demand)** — retrieves memory when needed
+- **Agent-Controlled Intelligent Recall (on demand)** — retrieves memory when needed
 
 ### 1. Advanced Augmentation (`agent_end` hook)
 
@@ -233,7 +249,7 @@ This runs in the background and **never blocks the agent's response**.
 
 ---
 
-### 2. Agent-controlled recall (plugin tools)
+### 2. Agent-Controlled Intelligent Recall (plugin tools)
 
 Memori does not automatically inject memory. The agent retrieves it explicitly.
 

--- a/docs/memori-cloud/openclaw/quickstart.mdx
+++ b/docs/memori-cloud/openclaw/quickstart.mdx
@@ -122,7 +122,7 @@ The Memori plugin operates on two parallel tracks:
 
 | Track | Mechanism | What it does |
 | --- | --- | --- |
-| **Agent-Controlled Recall** | Plugin Tools | Equips the agent with `memori_recall`, `memori_recall_summary`, and `memori_feedback`. The agent retrieves memory explicitly when needed. |
+| **Agent-Controlled Intelligent Recall** | Plugin Tools | Equips the agent with `memori_recall`, `memori_recall_summary`, and `memori_feedback`. The agent retrieves memory explicitly when needed. |
 | **Advanced Augmentation** | `agent_end` Hook | After the agent responds, the exchange and execution trace are sanitized and sent to Memori in the background to structure memory from conversation, tool activity, decisions, and outcomes. |
 
 Together, these systems continuously structure memory from not just natural language, but also from agent trace and execution. Memori captures the agent's actions, tool results, decisions, and outcomes into durable memory the agent can recall on demand — so the next time it performs a task, it is more accurate and efficient.

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -75,7 +75,7 @@ It runs **after the agent responds** and does not impact latency.
 
 ---
 
-### 2. Agent-controlled recall
+### 2. Agent-Controlled Intelligent Recall
 
 Recall is **explicit and initiated by the agent**.
 


### PR DESCRIPTION
## Summary

- Rename "Agent-Controlled Recall" to "Agent-Controlled Intelligent Recall" across OpenClaw docs
- Expand Section 3 in overview.mdx with intelligent recall description: Execution outcomes, Known failure modes
- Add colons to h4 headings to be consistent (`Memory classification schema:`, `Default behavior:`)