### PR TITLE
TS OC: remove query param from memori_recall tool

### DIFF
--- a/integrations/openclaw/package-lock.json
+++ b/integrations/openclaw/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memorilabs/openclaw-memori",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorilabs/openclaw-memori",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@memorilabs/memori": "0.1.12-beta"

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorilabs/openclaw-memori",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Official MemoriLabs.ai long-term memory plugin for OpenClaw",
   "type": "module",
   "main": "./dist/index.js",

--- a/integrations/openclaw/skills/clawhub/SKILL.md
+++ b/integrations/openclaw/skills/clawhub/SKILL.md
@@ -46,15 +46,18 @@ This is how structured memory is continuously built and updated over time. It ru
 Recall is explicit and initiated by the agent.
 
 Memori separates memory creation from memory recall:
+
 - Creation is automatic (advanced augmentation)
 - Recall is intentional (agent-controlled)
 
 Agents decide:
+
 - When to recall
 - What scope to recall from
 - How much history to include
 
 To maintain an efficient context window, Memori equips the agent with specific tools to retrieve history when required for the conversation:
+
 1. **`memori_recall`**: Searches the structured memory graph for specific facts, constraints, and prior decisions.
 2. **`memori_recall_summary`**: Retrieves structured daily briefs and rolling summaries of prior sessions.
 3. **`memori_feedback`**: Reports on memory quality to improve extraction accuracy.
@@ -105,11 +108,11 @@ Alternatively, configure it directly via JSON:
 
 When this plugin is active, the agent is equipped with tools to manage long-term context. The agent should use its discretion to call these tools when helpful:
 
-* **Contextual Recall**: The agent can run a `memori_recall` search to retrieve relevant details if context is missing regarding user preferences.
-* **Summaries**: The agent can utilize the `memori_recall_summary` tool to construct a brief if a user requests a recap. 
-* **Account Creation**: If a user explicitly asks to create an account, the agent can use the `memori_signup` tool to initiate the process by asking for an email address. Keys are never returned in the chat. The system securely emails the credentials to the user, who must then manually configure them to activate the plugin.
-* **Quota Monitoring**: The agent can use the `memori_quota` tool to check the user's current memory usage and storage limits to communicate quota status or gracefully degrade behavior if limits are reached.
-* **Date Defaults**: If the agent chooses to search memory, providing specific start/end dates is recommended to keep context windows efficient. Omitting dates will search all available history.
+- **Contextual Recall**: The agent can run a `memori_recall` search to retrieve relevant details if context is missing regarding user preferences.
+- **Summaries**: The agent can utilize the `memori_recall_summary` tool to construct a brief if a user requests a recap.
+- **Account Creation**: If a user explicitly asks to create an account, the agent can use the `memori_signup` tool to initiate the process by asking for an email address. Keys are never returned in the chat. The system securely emails the credentials to the user, who must then manually configure them to activate the plugin.
+- **Quota Monitoring**: The agent can use the `memori_quota` tool to check the user's current memory usage and storage limits to communicate quota status or gracefully degrade behavior if limits are reached.
+- **Date Defaults**: If the agent chooses to search memory, providing specific start/end dates is recommended to keep context windows efficient. Omitting dates will search all available history.
 
 ## Verification
 
@@ -160,10 +163,10 @@ Use this to monitor usage and upgrade if needed.
 
 **Explicit Opt-In Required:** Memori requires the user to explicitly configure an API key (`MEMORI_API_KEY`) and an `entityId`. **No data is captured or transmitted unless these credentials are actively provided by the user.**
 
-* ✅ Conversations are securely transmitted to the Memori backend (`https://api.memorilabs.ai`) only when the plugin is fully configured by the user.
-* ✅ Data is encrypted in transit and at rest.
-* ✅ Users control their data scope via their specific `projectId` and `entityId`.
-* ✅ The backend automatically filters sensitive data (API keys, passwords, secrets) prior to storage.
+- ✅ Conversations are securely transmitted to the Memori backend (`https://api.memorilabs.ai`) only when the plugin is fully configured by the user.
+- ✅ Data is encrypted in transit and at rest.
+- ✅ Users control their data scope via their specific `projectId` and `entityId`.
+- ✅ The backend automatically filters sensitive data (API keys, passwords, secrets) prior to storage.
 
 For details: [Memori Privacy Policy](https://memorilabs.ai/privacy)
 

--- a/integrations/openclaw/src/tools/memori-recall.ts
+++ b/integrations/openclaw/src/tools/memori-recall.ts
@@ -12,11 +12,6 @@ export function createMemoriRecallTool(deps: ToolDeps) {
     parameters: {
       type: 'object',
       properties: {
-        query: {
-          type: 'string',
-          description:
-            'REQUIRED: The natural language search query to find specific facts (e.g., "What database did we decide to use?", "Ryan\'s dogs"). DO NOT use wildcards like "*" or regex. This is a semantic search, so use real words.',
-        },
         dateStart: {
           type: 'string',
           description:
@@ -67,14 +62,11 @@ export function createMemoriRecallTool(deps: ToolDeps) {
           ],
         },
       },
-      // Force the LLM to ALWAYS provide a search query
-      required: ['query'],
     },
 
     async execute(
       _toolCallId: string,
       params: {
-        query: string;
         dateStart?: string;
         dateEnd?: string;
         projectId?: string;

--- a/integrations/openclaw/tests/tools/memori-recall.test.ts
+++ b/integrations/openclaw/tests/tools/memori-recall.test.ts
@@ -34,15 +34,9 @@ describe('tools/memori-recall', () => {
       expect(tool.label).toBe('Recall Memory');
     });
 
-    it('should require the query parameter', () => {
-      const tool = createMemoriRecallTool(deps);
-      expect(tool.parameters.required).toContain('query');
-    });
-
     it('should define expected parameter properties', () => {
       const tool = createMemoriRecallTool(deps);
       const props = tool.parameters.properties;
-      expect(props).toHaveProperty('query');
       expect(props).toHaveProperty('dateStart');
       expect(props).toHaveProperty('dateEnd');
       expect(props).toHaveProperty('projectId');

--- a/integrations/openclaw/tests/tools/memori-recall.test.ts
+++ b/integrations/openclaw/tests/tools/memori-recall.test.ts
@@ -51,7 +51,14 @@ describe('tools/memori-recall', () => {
       const { createRecallClient } = await import('../../src/utils/memori-client.js');
       const tool = createMemoriRecallTool(deps);
 
-      await tool.execute('call-1', { query: 'test query' });
+      await tool.execute('call-1', {
+        dateStart: '2024-01-01',
+        dateEnd: '2024-12-31',
+        projectId: 'proj-1',
+        sessionId: 'sess-1',
+        signal: 'user',
+        source: 'chat',
+      });
 
       expect(createRecallClient).toHaveBeenCalledWith('test-key', 'test-entity');
     });
@@ -60,7 +67,13 @@ describe('tools/memori-recall', () => {
       const { createRecallClient } = await import('../../src/utils/memori-client.js');
       const tool = createMemoriRecallTool(deps);
 
-      await tool.execute('call-1', { query: 'test' });
+      await tool.execute('call-1', {
+        dateStart: '2024-01-01',
+        dateEnd: '2024-12-31',
+        sessionId: 'sess-1',
+        signal: 'user',
+        source: 'chat',
+      });
 
       const client = vi.mocked(createRecallClient).mock.results[0].value;
       expect(client.agentRecall).toHaveBeenCalledWith(
@@ -72,7 +85,14 @@ describe('tools/memori-recall', () => {
       const { createRecallClient } = await import('../../src/utils/memori-client.js');
       const tool = createMemoriRecallTool(deps);
 
-      await tool.execute('call-1', { query: 'test', projectId: 'override-project' });
+      await tool.execute('call-1', {
+        dateStart: '2024-01-01',
+        dateEnd: '2024-12-31',
+        projectId: 'override-project',
+        sessionId: 'sess-1',
+        signal: 'user',
+        source: 'chat',
+      });
 
       const client = vi.mocked(createRecallClient).mock.results[0].value;
       expect(client.agentRecall).toHaveBeenCalledWith(
@@ -85,7 +105,6 @@ describe('tools/memori-recall', () => {
       const tool = createMemoriRecallTool(deps);
 
       await tool.execute('call-1', {
-        query: 'search query',
         dateStart: '2024-01-01',
         dateEnd: '2024-12-31',
         projectId: 'proj-1',
@@ -97,7 +116,6 @@ describe('tools/memori-recall', () => {
       const client = vi.mocked(createRecallClient).mock.results[0].value;
       expect(client.agentRecall).toHaveBeenCalledWith(
         expect.objectContaining({
-          query: 'search query',
           dateStart: '2024-01-01',
           dateEnd: '2024-12-31',
           projectId: 'proj-1',
@@ -116,7 +134,14 @@ describe('tools/memori-recall', () => {
       } as any);
 
       const tool = createMemoriRecallTool(deps);
-      const result = await tool.execute('call-1', { query: 'something' });
+      const result = await tool.execute('call-1', {
+        dateStart: '2024-01-01',
+        dateEnd: '2024-12-31',
+        projectId: 'proj-1',
+        sessionId: 'sess-1',
+        signal: 'user',
+        source: 'chat',
+      });
 
       expect(result.content).toHaveLength(1);
       expect(result.content[0].type).toBe('text');
@@ -133,7 +158,14 @@ describe('tools/memori-recall', () => {
       } as any);
 
       const tool = createMemoriRecallTool(deps);
-      const result = await tool.execute('call-1', { query: 'test' });
+      const result = await tool.execute('call-1', {
+        dateStart: '2024-01-01',
+        dateEnd: '2024-12-31',
+        projectId: 'proj-1',
+        sessionId: 'sess-1',
+        signal: 'user',
+        source: 'chat',
+      });
 
       expect(JSON.parse(result.content[0].text)).toEqual({ error: 'Recall failed' });
       expect(deps.logger.warn).toHaveBeenCalledWith(
@@ -146,7 +178,6 @@ describe('tools/memori-recall', () => {
       const tool = createMemoriRecallTool(deps);
 
       const result = await tool.execute('call-1', {
-        query: 'test',
         projectId: '',
         sessionId: 'sess-1',
       });
@@ -161,7 +192,6 @@ describe('tools/memori-recall', () => {
       const tool = createMemoriRecallTool(deps);
 
       const result = await tool.execute('call-1', {
-        query: 'test',
         projectId: 'proj-1',
         sessionId: 'sess-1',
       });
@@ -174,7 +204,14 @@ describe('tools/memori-recall', () => {
     it('should log params before executing', async () => {
       const tool = createMemoriRecallTool(deps);
 
-      await tool.execute('call-1', { query: 'log test' });
+      await tool.execute('call-1', {
+        dateStart: '2024-01-01',
+        dateEnd: '2024-12-31',
+        projectId: 'proj-1',
+        sessionId: 'sess-1',
+        signal: 'user',
+        source: 'chat',
+      });
 
       expect(deps.logger.info).toHaveBeenCalledWith(
         expect.stringContaining('memori_recall params')


### PR DESCRIPTION
- There was leftover  code for a query param in the tool logic, it needs to be removed,  no logic changes
- update unit test for this change