### PR TITLE
fix(openclaw): declare missing tool contracts and register signup before config guard

### DIFF
--- a/integrations/openclaw/openclaw.plugin.json
+++ b/integrations/openclaw/openclaw.plugin.json
@@ -6,7 +6,13 @@
   "kind": "memory",
   "main": "dist/index.js",
   "contracts": {
-    "tools": ["memori_recall", "memori_recall_summary", "memori_feedback"]
+    "tools": [
+      "memori_recall",
+      "memori_recall_summary",
+      "memori_feedback",
+      "memori_signup",
+      "memori_quota"
+    ]
   },
   "uiHints": {
     "apiKey": {

--- a/integrations/openclaw/openclaw.plugin.json
+++ b/integrations/openclaw/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-memori",
   "name": "Memori System",
-  "version": "0.0.10",
+  "version": "0.0.13",
   "description": "Hosted memory backend",
   "kind": "memory",
   "main": "dist/index.js",

--- a/integrations/openclaw/package-lock.json
+++ b/integrations/openclaw/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memorilabs/openclaw-memori",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorilabs/openclaw-memori",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@memorilabs/memori": "0.1.12-beta"

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorilabs/openclaw-memori",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Official MemoriLabs.ai long-term memory plugin for OpenClaw",
   "type": "module",
   "main": "./dist/index.js",

--- a/integrations/openclaw/src/index.ts
+++ b/integrations/openclaw/src/index.ts
@@ -3,7 +3,7 @@ import { handleAugmentation } from './handlers/augmentation.js';
 import { OpenClawEvent, OpenClawContext, MemoriPluginConfig } from './types.js';
 import { PLUGIN_CONFIG } from './constants.js';
 import { MemoriLogger, loadSkillsContent } from './utils/index.js';
-import { registerAllTools } from './tools/index.js';
+import { registerUtilityTools, registerAuthenticatedTools } from './tools/index.js';
 import { registerCliCommands } from './cli/commands.js';
 
 const memoriPlugin = {
@@ -22,15 +22,17 @@ const memoriPlugin = {
       projectId: rawConfig?.projectId as string,
     };
 
+    const logger = new MemoriLogger(api);
+    const skillsContent = loadSkillsContent(api.resolvePath.bind(api));
+
+    registerUtilityTools({ api, config, logger });
+
     if (!config.apiKey || !config.entityId) {
       api.logger.warn(
         `${PLUGIN_CONFIG.LOG_PREFIX} Missing apiKey or entityId in config. Plugin disabled.`
       );
       return;
     }
-
-    const logger = new MemoriLogger(api);
-    const skillsContent = loadSkillsContent(api.resolvePath.bind(api));
 
     logger.info(`\n=== ${PLUGIN_CONFIG.LOG_PREFIX} INITIALIZING PLUGIN ===`);
     logger.info(`${PLUGIN_CONFIG.LOG_PREFIX} Tracking Entity ID: ${config.entityId}`);
@@ -43,7 +45,7 @@ const memoriPlugin = {
       handleAugmentation(event as OpenClawEvent, ctx as OpenClawContext, config, logger)
     );
 
-    registerAllTools({ api, config, logger });
+    registerAuthenticatedTools({ api, config, logger });
   },
 };
 

--- a/integrations/openclaw/src/tools/index.ts
+++ b/integrations/openclaw/src/tools/index.ts
@@ -5,12 +5,15 @@ import { createMemoriRecallSummaryTool } from './memori-recall-summary.js';
 import { createMemoriFeedbackTool } from './memori-feedback.js';
 import type { ToolDeps } from './types.js';
 
-export function registerAllTools(deps: ToolDeps): void {
+export function registerUtilityTools(deps: ToolDeps): void {
   deps.api.registerTool(createMemoriSignupTool(deps));
-  deps.api.registerTool(createMemoriQuotaTool(deps));
+}
+
+export function registerAuthenticatedTools(deps: ToolDeps): void {
   deps.api.registerTool(createMemoriRecallTool(deps));
   deps.api.registerTool(createMemoriRecallSummaryTool(deps));
   deps.api.registerTool(createMemoriFeedbackTool(deps));
+  deps.api.registerTool(createMemoriQuotaTool(deps));
 }
 
 export type { ToolDeps };


### PR DESCRIPTION
## Problem

Two bugs causing tools to not appear after install:

**1. Missing contract declarations**
`openclaw.plugin.json` declared only 3 tools in `contracts.tools`, but the plugin registered 5. The gateway blocked `memori_signup` and `memori_quota` at registration time. Because `memori_signup` was the first tool registered, this aborted the registration loop before `memori_recall`, `memori_recall_summary`, and `memori_feedback` could be registered — leaving users with zero tools until a restart resolved whatever timing issue prevented the gateway from completing registration cleanly.

**2. Signup gated behind the API key it's meant to provide**
`memori_signup` was registered inside the `if (!config.apiKey || !config.entityId)` guard. A brand new user with no key yet could never call `memori_signup` to get one.

## Changes

- `openclaw.plugin.json` — added `memori_signup` and `memori_quota` to `contracts.tools`
- `src/tools/index.ts` — split `registerAllTools` into `registerUtilityTools` (signup) and `registerAuthenticatedTools` (recall, recall_summary, feedback, quota)
- `src/index.ts` — call `registerUtilityTools` before the config guard so signup is always available; authenticated tools still require `apiKey` + `entityId`