### PR TITLE
docs: add Prisma BYODB example and clarify Anthropic support

### DIFF
--- a/docs/memori-byodb/databases/cockroachdb-typescript.mdx
+++ b/docs/memori-byodb/databases/cockroachdb-typescript.mdx
@@ -57,14 +57,6 @@ await pool.end();
 
 </CodeGroup>
 
-## Connection Strings
-
-| Environment           | Connection String                                                               |
-| --------------------- | ------------------------------------------------------------------------------- |
-| **Local**             | `postgresql://root@localhost:26257/memori_db?sslmode=disable`                   |
-| **With Auth**         | `postgresql://user:pass@host:26257/memori_db`                                   |
-| **CockroachDB Cloud** | `postgresql://user:pass@cluster.cockroachlabs.cloud:26257/memori_db?sslmode=verify-full` |
-
 ## Complete Example
 
 ```typescript

--- a/docs/memori-byodb/databases/mysql-typescript.mdx
+++ b/docs/memori-byodb/databases/mysql-typescript.mdx
@@ -55,15 +55,6 @@ await pool.end();
 
 </CodeGroup>
 
-## Connection Strings
-
-| Environment     | Connection String                                                |
-| --------------- | ---------------------------------------------------------------- |
-| **Local**       | `mysql://user:password@localhost:3306/memori_db`                 |
-| **With SSL**    | `mysql://user:password@host:3306/memori_db?ssl=true`             |
-| **PlanetScale** | `mysql://user:password@host.psdb.cloud/memori_db?ssl={"rejectUnauthorized":true}` |
-| **AWS RDS**     | `mysql://user:password@xxx.rds.amazonaws.com:3306/memori_db`     |
-
 ## Complete Example
 
 ```typescript

--- a/docs/memori-byodb/databases/postgres-typescript.mdx
+++ b/docs/memori-byodb/databases/postgres-typescript.mdx
@@ -56,16 +56,6 @@ await pool.end();
 
 </CodeGroup>
 
-## Connection Strings
-
-| Environment     | Connection String                                                        |
-| --------------- | ------------------------------------------------------------------------ |
-| **Local**       | `postgresql://user:password@localhost:5432/memori_db`                    |
-| **With SSL**    | `postgresql://user:password@host:5432/memori_db?sslmode=require`         |
-| **Neon**        | `postgresql://user:password@ep-xxx.neon.tech/memori_db?sslmode=require`  |
-| **Supabase**    | `postgresql://postgres:password@db.xxx.supabase.co:5432/postgres`        |
-| **AWS RDS**     | `postgresql://user:password@xxx.rds.amazonaws.com:5432/memori_db`        |
-
 ## Complete Example
 
 ```typescript

--- a/docs/memori-byodb/databases/typescript-orm.mdx
+++ b/docs/memori-byodb/databases/typescript-orm.mdx
@@ -22,6 +22,43 @@ const db = drizzle(pool);
 const mem = new Memori({ conn: () => pool });
 ```
 
+## Prisma
+
+Prisma uses `@prisma/adapter-pg` which accepts a `pg.Pool` directly — pass that same pool to Memori so both share one connection.
+
+```typescript
+import 'dotenv/config';
+import pg from 'pg';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { PrismaClient } from '../generated/prisma/client';
+import { OpenAI } from 'openai';
+import { Memori } from '@memorilabs/memori';
+
+const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL });
+const adapter = new PrismaPg(pool);
+const prisma = new PrismaClient({ adapter });
+
+const client = new OpenAI();
+const mem = new Memori({ conn: () => pool }).llm.register(client);
+mem.attribution('user-123', 'my-app');
+
+if (!mem.config.storage) {
+  throw new Error('Storage not initialized');
+}
+
+await mem.config.storage.build();
+
+const response = await client.chat.completions.create({
+  model: 'gpt-4o-mini',
+  messages: [{ role: 'user', content: 'My favorite color is blue.' }],
+});
+console.log(`AI: ${response.choices[0]?.message?.content}`);
+
+await mem.augmentation.wait();
+await prisma.$disconnect();
+await pool.end();
+```
+
 ## Drizzle
 
 <CodeGroup title="Drizzle">

--- a/docs/memori-byodb/llm/typescript-anthropic.mdx
+++ b/docs/memori-byodb/llm/typescript-anthropic.mdx
@@ -52,10 +52,10 @@ await mem.augmentation.wait();
 | Mode         | TypeScript                         | Python                           |
 | ------------ | ---------------------------------- | -------------------------------- |
 | **Async**    | `await client.messages.create()`   | `await client.messages.create()` |
-| **Streamed** | `client.messages.stream()`         | `client.messages.stream()`       |
+| **Streamed** | Not supported                      | `client.messages.stream()`       |
 | **Sync**     | —                                  | `client.messages.create()`       |
 
-## Streaming
+## Multi-Turn
 
 ```typescript
 import 'dotenv/config';
@@ -75,17 +75,25 @@ if (!mem.config.storage) {
 
 await mem.config.storage.build();
 
-const stream = client.messages.stream({
+const messages: Anthropic.MessageParam[] = [];
+
+messages.push({ role: 'user', content: 'My favorite color is blue.' });
+const first = await client.messages.create({
   model: 'claude-sonnet-4-6',
   max_tokens: 1024,
-  messages: [{ role: 'user', content: 'Hello!' }],
+  messages,
 });
+const firstText = first.content[0].type === 'text' ? first.content[0].text : '';
+console.log(`Assistant: ${firstText}`);
+messages.push({ role: 'assistant', content: firstText });
 
-for await (const chunk of stream) {
-  if (chunk.type === 'content_block_delta' && chunk.delta.type === 'text_delta') {
-    process.stdout.write(chunk.delta.text);
-  }
-}
+messages.push({ role: 'user', content: 'What did I just tell you?' });
+const second = await client.messages.create({
+  model: 'claude-sonnet-4-6',
+  max_tokens: 1024,
+  messages,
+});
+console.log(`Assistant: ${second.content[0].type === 'text' ? second.content[0].text : ''}`);
 
 await mem.augmentation.wait();
 ```


### PR DESCRIPTION
## Summary
- Add a Prisma BYODB TypeScript example that shares a `pg.Pool` between Prisma and Memori.
- Update the Anthropic TypeScript docs to show multi-turn usage instead of streaming, since streaming is not currently supported.
- Remove duplicated connection string tables from the Postgres, MySQL, and CockroachDB TypeScript pages.