### PR TITLE
Enhance Memori installation process for Hermes integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Memori also ships as a Hermes Agent memory provider. It captures completed conve
 
 ```bash
 pip install hermes-memori
+hermes-memori install
 
 hermes config set memory.provider memori
 HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"

--- a/docs/memori-cloud/hermes/quickstart.mdx
+++ b/docs/memori-cloud/hermes/quickstart.mdx
@@ -23,10 +23,12 @@ This means Hermes can remember what happened during prior work — tool usage, w
 
 ```bash
 pip install hermes-memori
+hermes-memori install
 ```
 
-If `memori` does not appear in Hermes' memory setup flow, install
-`hermes-memori` in the same Python environment that Hermes uses.
+Install `hermes-memori` in the same Python environment that Hermes uses.
+The `hermes-memori install` command registers the provider in Hermes' memory
+plugin directory at `$HERMES_HOME/plugins/memori`.
 
 ## 2. Configure
 
@@ -108,6 +110,7 @@ You should see `memori` configured as the active memory provider.
 If the provider is unavailable, confirm that:
 
 - `hermes-memori` is installed in the same Python environment as Hermes
+- `hermes-memori install` has been run for the same `HERMES_HOME`
 - `memory.provider` is set to `memori`
 - `MEMORI_API_KEY` and `MEMORI_ENTITY_ID` are set
 

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -172,6 +172,7 @@ Available tools:
 
 ```bash
 pip install hermes-memori
+hermes-memori install
 ```
 
 For local development from this repository:
@@ -179,7 +180,12 @@ For local development from this repository:
 ```bash
 pip install -e .
 pip install -e integrations/hermes
+hermes-memori install --force
 ```
+
+The `hermes-memori install` command registers the provider in Hermes' memory
+plugin directory at `$HERMES_HOME/plugins/memori`, which is where Hermes scans
+for user-installed memory providers.
 
 ### 2. Configure
 

--- a/integrations/hermes/pyproject.toml
+++ b/integrations/hermes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-memori"
-version = "0.1.3"
+version = "0.1.4"
 description = "Official Memori Labs provider for Hermes Agent, enabling structured long-term memory from agent trace and execution."
 authors = [{name = "Memori Labs Team", email = "noc@memorilabs.ai"}]
 license = "Apache-2.0"
@@ -25,6 +25,9 @@ classifiers = [
 
 [project.entry-points."hermes_agent.plugins"]
 memori = "memori_hermes:register"
+
+[project.scripts]
+hermes-memori = "memori_hermes.install:main"
 
 [project.urls]
 Homepage = "https://memorilabs.ai"

--- a/integrations/hermes/src/memori_hermes/install.py
+++ b/integrations/hermes/src/memori_hermes/install.py
@@ -1,0 +1,149 @@
+"""Installer CLI for the Memori Hermes memory provider."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+from pathlib import Path
+
+PLUGIN_NAME = "memori"
+EXCLUDED_DIRS = {"__pycache__", ".pytest_cache", ".ruff_cache"}
+EXCLUDED_SUFFIXES = {".pyc", ".pyo"}
+
+
+def hermes_home() -> Path:
+    """Return the Hermes home directory used for user-installed plugins."""
+    return Path(os.environ.get("HERMES_HOME") or "~/.hermes").expanduser()
+
+
+def plugin_source_dir() -> Path:
+    """Return the installed memori_hermes package directory."""
+    return Path(__file__).resolve().parent
+
+
+def plugin_target_dir(hermes_home_path: str | Path | None = None) -> Path:
+    """Return the Hermes memory plugin destination for Memori."""
+    base = Path(hermes_home_path).expanduser() if hermes_home_path else hermes_home()
+    return base / "plugins" / PLUGIN_NAME
+
+
+def _ignore_copy_names(_directory: str, names: list[str]) -> set[str]:
+    ignored: set[str] = set()
+    for name in names:
+        path = Path(name)
+        if name in EXCLUDED_DIRS or path.suffix in EXCLUDED_SUFFIXES:
+            ignored.add(name)
+    return ignored
+
+
+def install_plugin(
+    *,
+    hermes_home_path: str | Path | None = None,
+    force: bool = False,
+) -> Path:
+    """Install the Memori provider into Hermes' user plugin directory."""
+    source = plugin_source_dir()
+    target = plugin_target_dir(hermes_home_path)
+
+    if target.exists():
+        if not force:
+            raise FileExistsError(
+                f"{target} already exists. Re-run with --force to replace it."
+            )
+        shutil.rmtree(target)
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(source, target, ignore=_ignore_copy_names)
+    return target
+
+
+def uninstall_plugin(*, hermes_home_path: str | Path | None = None) -> Path:
+    """Remove the Memori provider from Hermes' user plugin directory."""
+    target = plugin_target_dir(hermes_home_path)
+    if target.exists():
+        shutil.rmtree(target)
+    return target
+
+
+def is_installed(*, hermes_home_path: str | Path | None = None) -> bool:
+    """Return whether the Memori provider is installed for Hermes discovery."""
+    target = plugin_target_dir(hermes_home_path)
+    return (target / "__init__.py").is_file() and (target / "plugin.yaml").is_file()
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="hermes-memori",
+        description="Install the Memori memory provider for Hermes Agent.",
+    )
+    parser.add_argument(
+        "--hermes-home",
+        help="Hermes home directory. Defaults to HERMES_HOME or ~/.hermes.",
+    )
+
+    subparsers = parser.add_subparsers(dest="command")
+
+    install = subparsers.add_parser(
+        "install",
+        help="Install Memori into Hermes' memory provider plugin directory.",
+    )
+    install.add_argument(
+        "--force",
+        action="store_true",
+        help="Replace an existing Memori plugin directory.",
+    )
+
+    subparsers.add_parser(
+        "uninstall",
+        help="Remove Memori from Hermes' memory provider plugin directory.",
+    )
+    subparsers.add_parser(
+        "status",
+        help="Show whether Memori is installed for Hermes memory discovery.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the hermes-memori installer CLI."""
+    parser = _parser()
+    args = parser.parse_args(argv)
+    command = args.command or "install"
+
+    try:
+        if command == "install":
+            target = install_plugin(
+                hermes_home_path=args.hermes_home,
+                force=getattr(args, "force", False),
+            )
+            print(f"Installed Memori Hermes provider to {target}")
+            print("Next steps:")
+            print("  hermes config set memory.provider memori")
+            print("  hermes memory setup")
+            print("  hermes memory status")
+            return 0
+
+        if command == "uninstall":
+            target = uninstall_plugin(hermes_home_path=args.hermes_home)
+            print(f"Removed Memori Hermes provider from {target}")
+            return 0
+
+        if command == "status":
+            target = plugin_target_dir(args.hermes_home)
+            if is_installed(hermes_home_path=args.hermes_home):
+                print(f"Memori Hermes provider is installed at {target}")
+                return 0
+            print(f"Memori Hermes provider is not installed at {target}")
+            return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/integrations/hermes/tests/test_install.py
+++ b/integrations/hermes/tests/test_install.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from memori_hermes.install import (  # noqa: E402
+    install_plugin,
+    is_installed,
+    main,
+    plugin_target_dir,
+    uninstall_plugin,
+)
+
+
+def test_install_plugin_copies_provider_to_hermes_plugins(tmp_path: Path) -> None:
+    target = install_plugin(hermes_home_path=tmp_path)
+
+    assert target == tmp_path / "plugins" / "memori"
+    assert (target / "__init__.py").is_file()
+    assert (target / "plugin.yaml").is_file()
+    assert (target / "client.py").is_file()
+    assert (target / "tools.py").is_file()
+    assert is_installed(hermes_home_path=tmp_path)
+
+
+def test_install_plugin_uses_hermes_home_env(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    target = install_plugin()
+
+    assert target == tmp_path / "plugins" / "memori"
+    assert is_installed()
+
+
+def test_install_plugin_requires_force_for_existing_target(tmp_path: Path) -> None:
+    install_plugin(hermes_home_path=tmp_path)
+
+    try:
+        install_plugin(hermes_home_path=tmp_path)
+    except FileExistsError as exc:
+        assert "--force" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected FileExistsError")
+
+
+def test_install_plugin_force_replaces_existing_target(tmp_path: Path) -> None:
+    target = install_plugin(hermes_home_path=tmp_path)
+    marker = target / "old.txt"
+    marker.write_text("old", encoding="utf-8")
+
+    install_plugin(hermes_home_path=tmp_path, force=True)
+
+    assert not marker.exists()
+    assert is_installed(hermes_home_path=tmp_path)
+
+
+def test_install_plugin_excludes_cache_files(tmp_path: Path) -> None:
+    target = install_plugin(hermes_home_path=tmp_path)
+
+    assert not list(target.rglob("__pycache__"))
+    assert not list(target.rglob("*.pyc"))
+
+
+def test_uninstall_plugin_removes_memori_directory_only(tmp_path: Path) -> None:
+    target = install_plugin(hermes_home_path=tmp_path)
+    sibling = tmp_path / "plugins" / "other"
+    sibling.mkdir()
+
+    removed = uninstall_plugin(hermes_home_path=tmp_path)
+
+    assert removed == target
+    assert not target.exists()
+    assert sibling.exists()
+
+
+def test_status_command_returns_zero_when_installed(tmp_path: Path, capsys) -> None:
+    install_plugin(hermes_home_path=tmp_path)
+
+    result = main(["--hermes-home", str(tmp_path), "status"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "is installed" in captured.out
+
+
+def test_status_command_returns_one_when_missing(tmp_path: Path, capsys) -> None:
+    result = main(["--hermes-home", str(tmp_path), "status"])
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "is not installed" in captured.out
+
+
+def test_install_command_defaults_to_install(tmp_path: Path, capsys) -> None:
+    result = main(["--hermes-home", str(tmp_path)])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "Installed Memori Hermes provider" in captured.out
+    assert is_installed(hermes_home_path=tmp_path)
+
+
+def test_plugin_target_dir_expands_user(monkeypatch) -> None:
+    monkeypatch.setenv("HOME", "/tmp/hermes-memori-home")
+
+    target = plugin_target_dir("~/custom-hermes")
+
+    assert str(target) == os.path.expanduser("~/custom-hermes/plugins/memori")


### PR DESCRIPTION
- Added `hermes-memori install` command to the README and quickstart documentation to clarify installation steps.
- Implemented an installer CLI for the Memori memory provider, allowing users to install, uninstall, and check the status of the provider.
- Updated the `pyproject.toml` to include the new command as a script entry point.
- Added tests for the installation functionality to ensure proper behavior and error handling.