### PR TITLE
Remove irrelevant providers from the Install your LLM Provider section

### DIFF
--- a/docs/memori-byodb/getting-started/installation.mdx
+++ b/docs/memori-byodb/getting-started/installation.mdx
@@ -207,9 +207,6 @@ pip install anthropic
 pip install google-genai
 ```
 
-```bash {{ title: 'LangChain' }}
-pip install langchain-openai
-```
 
 </CodeGroup>
 

--- a/docs/memori-cloud/getting-started/installation.mdx
+++ b/docs/memori-cloud/getting-started/installation.mdx
@@ -45,25 +45,6 @@ pip install anthropic
 pip install google-genai
 ```
 
-```bash {{ title: 'xAI Grok' }}
-pip install openai
-```
-
-```bash {{ title: 'Nebius AI Studio' }}
-pip install openai
-```
-
-```bash {{ title: 'AWS Bedrock' }}
-pip install langchain-aws
-```
-
-```bash {{ title: 'LangChain' }}
-pip install langchain-openai
-```
-
-```bash {{ title: 'Pydantic AI' }}
-pip install pydantic-ai
-```
 
 </CodeGroup>
 


### PR DESCRIPTION
Remove LangChain, xAI Grok, Nebius AI Studio, AWS Bedrock from the Install your LLM Provider section