### PR TITLE
Improved the BYODB, Cloud docs and verified them against the Python and TypeScript SDK source code

### DIFF
--- a/docs/memori-byodb/concepts/knowledge-graph.mdx
+++ b/docs/memori-byodb/concepts/knowledge-graph.mdx
@@ -79,7 +79,7 @@ Since the knowledge graph lives in your database, you can query it directly for 
 ```sql {{ title: 'View All Triples' }}
 SELECT
     s.name AS subject,
-    p.name AS predicate,
+    p.content AS predicate,
     o.name AS object
 FROM memori_knowledge_graph kg
 JOIN memori_subject s ON kg.subject_id = s.id
@@ -90,23 +90,25 @@ JOIN memori_object o ON kg.object_id = o.id;
 ```sql {{ title: 'Triples for an Entity' }}
 SELECT
     s.name AS subject,
-    p.name AS predicate,
+    p.content AS predicate,
     o.name AS object,
-    kg.mention_count,
-    kg.last_mentioned_at
+    kg.num_times,
+    kg.date_last_time
 FROM memori_knowledge_graph kg
+JOIN memori_entity e ON kg.entity_id = e.id
 JOIN memori_subject s ON kg.subject_id = s.id
 JOIN memori_predicate p ON kg.predicate_id = p.id
 JOIN memori_object o ON kg.object_id = o.id
-WHERE kg.entity_id = 'user_alice'
-ORDER BY kg.mention_count DESC;
+WHERE e.external_id = 'user_alice'
+ORDER BY kg.num_times DESC;
 ```
 
 ```sql {{ title: 'View Facts' }}
-SELECT content, created_at
-FROM memori_entity_fact
-WHERE entity_id = 'user_alice'
-ORDER BY created_at DESC;
+SELECT content, date_created
+FROM memori_entity_fact ef
+JOIN memori_entity e ON ef.entity_id = e.id
+WHERE e.external_id = 'user_alice'
+ORDER BY date_created DESC;
 ```
 
 </CodeGroup>

--- a/docs/memori-byodb/contribute/development-setup.mdx
+++ b/docs/memori-byodb/contribute/development-setup.mdx
@@ -16,9 +16,14 @@ This guide walks you through setting up a local development environment for work
 
 Before you begin, make sure you have the following installed on your system:
 
-- **Python 3.10 or higher** — Memori requires Python 3.10+. Check your version with `python --version`.
 - **git** — For cloning the repository and managing branches.
+
+**Python:**
+- **Python 3.10 or higher** — Check your version with `python --version`.
 - **pip** — Python's package manager (usually included with Python).
+
+**TypeScript:**
+- **Node.js 20 or higher** — Check your version with `node --version`.
 
 ## Clone the Repository
 
@@ -38,67 +43,50 @@ git fetch upstream
 
 ## Install Dependencies
 
-It is recommended to use a virtual environment to avoid conflicts with other Python projects:
+<CodeGroup title="Install Dependencies">
 
-<CodeGroup title="Virtual Environment Setup">
-
-```bash {{ title: 'venv (Built-in)' }}
+```bash {{ title: 'Python' }}
+# Create and activate a virtual environment
 python -m venv .venv
 source .venv/bin/activate    # macOS/Linux
 # .venv\Scripts\activate     # Windows
+
+# Install with development dependencies
+pip install -e ".[dev]"
 ```
 
-```bash {{ title: 'conda' }}
-conda create -n memori python=3.12
-conda activate memori
+```bash {{ title: 'TypeScript' }}
+cd memori-ts
+npm install
 ```
 
 </CodeGroup>
 
-Once your virtual environment is active, install Memori with development dependencies:
-
-```bash
-pip install -e ".[dev]"
-```
-
-This installs Memori in editable mode (`-e`) so that changes you make to the source code are immediately reflected without reinstalling. The `[dev]` extra includes testing and linting tools.
-
-If the project uses a `requirements-dev.txt` file instead, install with:
-
-```bash
-pip install -e .
-pip install -r requirements-dev.txt
-```
+The Python `-e` flag installs Memori in editable mode so changes to the source code are immediately reflected without reinstalling. The `[dev]` extra includes testing and linting tools.
 
 ## Running Tests
 
-Memori uses pytest for its test suite. Run all tests from the project root:
+<CodeGroup title="Run Tests">
 
-```bash
+```bash {{ title: 'Python' }}
+# Run all tests
 pytest
-```
 
-To run tests with verbose output:
-
-```bash
+# Run with verbose output
 pytest -v
-```
 
-To run a specific test file or test function:
+# Run a specific test file
+pytest tests/test_config.py
 
-```bash
-# Run all tests in a specific file
-pytest tests/test_openai.py
-
-# Run a specific test function
-pytest tests/test_openai.py::test_sync_completion
-```
-
-To run tests with coverage reporting:
-
-```bash
+# Run with coverage
 pytest --cov=memori --cov-report=term-missing
 ```
+
+```bash {{ title: 'TypeScript' }}
+npm test
+```
+
+</CodeGroup>
 
 ## Local Development Workflow
 
@@ -110,25 +98,45 @@ Here is a typical workflow for making changes to Memori:
    git checkout -b feat/my-new-feature
    ```
 
-2. **Make your changes** — Edit the source code in the `memori/` directory.
+2. **Make your changes** — Edit the source code in the `memori/` directory (Python) or `memori-ts/src/` directory (TypeScript).
 
-3. **Write tests** — Add or update tests in the `tests/` directory to cover your changes.
+3. **Write tests** — Add or update tests in the `tests/` directory (Python) or `memori-ts/` (TypeScript) to cover your changes.
 
 4. **Run the tests** to make sure nothing is broken:
 
-   ```bash
+   <CodeGroup title="Run Tests">
+
+   ```bash {{ title: 'Python' }}
    pytest
    ```
 
-5. **Check code style** — The project uses Ruff for linting and formatting:
+   ```bash {{ title: 'TypeScript' }}
+   npm test
+   ```
 
-   ```bash
+   </CodeGroup>
+
+5. **Check code style:**
+
+   <CodeGroup title="Code Style">
+
+   ```bash {{ title: 'Python' }}
    # Lint
    ruff check .
 
    # Format
    ruff format --check .
    ```
+
+   ```bash {{ title: 'TypeScript' }}
+   # Lint
+   npm run lint
+
+   # Type check
+   npm run typecheck
+   ```
+
+   </CodeGroup>
 
 6. **Commit your changes** with a descriptive message:
 
@@ -146,11 +154,12 @@ Here is a typical workflow for making changes to Memori:
 
 Here is a high-level overview of the Memori repository structure:
 
-| Directory   | Purpose                         |
-| ----------- | ------------------------------- |
-| `memori/`   | Core library source code        |
-| `tests/`    | Test suite (pytest)             |
-| `docs/`     | Documentation source files      |
-| `examples/` | Example scripts and usage demos |
+| Directory    | Purpose                                   |
+| ------------ | ----------------------------------------- |
+| `memori/`    | Python library source code                |
+| `memori-ts/` | TypeScript library source code            |
+| `tests/`     | Python test suite (pytest)                |
+| `docs/`      | Documentation source files                |
+| `examples/`  | Example scripts and usage demos           |
 
-The core integration logic for each LLM provider typically lives in separate modules within the `memori/` directory. When adding support for a new provider, look at existing integrations (such as OpenAI or Anthropic) as templates.
+The core integration logic for each LLM provider lives in separate modules within `memori/` (Python) and `memori-ts/src/` (TypeScript). When adding support for a new provider, look at existing integrations (such as OpenAI or Anthropic) as templates.

--- a/docs/memori-byodb/contribute/overview.mdx
+++ b/docs/memori-byodb/contribute/overview.mdx
@@ -25,7 +25,9 @@ Found a bug? Open an issue on [GitHub](https://github.com/MemoriLabs/Memori/issu
 - A clear title describing the problem
 - Steps to reproduce the issue
 - What you expected to happen versus what actually happened
-- Your Python version, OS, and Memori version (`pip show memori`)
+- Your OS and Memori version
+  - Python: your Python version and `pip show memori`
+  - TypeScript: your Node.js version and `npm list @memorilabs/memori`
 
 ### Suggest Features
 

--- a/docs/memori-byodb/getting-started/typescript-quickstart.mdx
+++ b/docs/memori-byodb/getting-started/typescript-quickstart.mdx
@@ -58,7 +58,7 @@ Create a new file `quickstart.ts` and add the following code:
 
 Import libraries, open a SQLite database, and initialize Memori with your OpenAI client.
 
-- `conn` accepts the raw database connection (a `better-sqlite3` `Database` instance, `pg` Pool, or `mysql2` Pool)
+- `conn` accepts a factory function that returns the database connection (a `better-sqlite3` `Database` instance, `pg` Pool, or `mysql2` Pool)
 - `llm.register()` wraps your LLM client for automatic memory capture
 - `attribution()` links memories to a specific user and process
 - `await mem.config.storage.build()` creates the Memori schema tables in your database

--- a/docs/memori-byodb/llm/agno.mdx
+++ b/docs/memori-byodb/llm/agno.mdx
@@ -12,6 +12,7 @@ Memori integrates with Agno at the model layer. Register your Agno model with `l
   [app.memorilabs.ai](https://app.memorilabs.ai).
 </Note>
 
+
 ## Quick Start
 
 <CodeGroup title="Agno Integration">

--- a/docs/memori-byodb/llm/aws-bedrock.mdx
+++ b/docs/memori-byodb/llm/aws-bedrock.mdx
@@ -12,6 +12,7 @@ Memori supports AWS Bedrock through `langchain-aws`. Register using the `chatbed
   [app.memorilabs.ai](https://app.memorilabs.ai).
 </Note>
 
+
 ## Quick Start
 
 <CodeGroup title="Bedrock Integration">

--- a/docs/memori-byodb/llm/deepseek.mdx
+++ b/docs/memori-byodb/llm/deepseek.mdx
@@ -12,6 +12,7 @@ DeepSeek provides an OpenAI-compatible API. Use the `openai` Python package with
   [app.memorilabs.ai](https://app.memorilabs.ai).
 </Note>
 
+
 ## Quick Start
 
 <CodeGroup title="DeepSeek Integration">

--- a/docs/memori-byodb/llm/langchain.mdx
+++ b/docs/memori-byodb/llm/langchain.mdx
@@ -12,6 +12,7 @@ Memori supports any LangChain chat model. Each class has its own registration ke
   [app.memorilabs.ai](https://app.memorilabs.ai).
 </Note>
 
+
 ## Quick Start
 
 <CodeGroup title="LangChain Integration">

--- a/docs/memori-byodb/llm/nebius.mdx
+++ b/docs/memori-byodb/llm/nebius.mdx
@@ -12,6 +12,7 @@ Nebius AI Studio provides an OpenAI-compatible API. Use the `openai` Python pack
   [app.memorilabs.ai](https://app.memorilabs.ai).
 </Note>
 
+
 ## Quick Start
 
 <CodeGroup title="Nebius AI Studio Integration">

--- a/docs/memori-byodb/llm/overview.mdx
+++ b/docs/memori-byodb/llm/overview.mdx
@@ -14,22 +14,22 @@ Memori works with all major LLM providers and frameworks. Register any supported
 
 ## Supported Providers
 
-| Provider                                              | Integration        | Install                               |
-| ----------------------------------------------------- | ------------------ | ------------------------------------- |
-| **[OpenAI](/docs/memori-byodb/llm/openai)**           | Direct SDK wrapper | `pip install memori openai`           |
-| **[Anthropic](/docs/memori-byodb/llm/anthropic)**     | Direct SDK wrapper | `pip install memori anthropic`        |
-| **[Google Gemini](/docs/memori-byodb/llm/gemini)**    | Direct SDK wrapper | `pip install memori google-genai`     |
-| **[xAI Grok](/docs/memori-byodb/llm/xai-grok)**       | OpenAI-compatible  | `pip install memori openai`           |
-| **[AWS Bedrock](/docs/memori-byodb/llm/aws-bedrock)** | LangChain adapter  | `pip install memori langchain-aws`    |
-| **[LangChain](/docs/memori-byodb/llm/langchain)**     | Framework support  | `pip install memori langchain-openai` |
-| **[Agno](/docs/memori-byodb/llm/agno)**               | Framework support  | `pip install memori agno`             |
-| **[Pydantic AI](/docs/memori-byodb/llm/pydantic-ai)** | Framework support  | `pip install memori pydantic-ai`      |
-| **[Nebius AI Studio](/docs/memori-byodb/llm/nebius)** | OpenAI-compatible  | `pip install memori openai`           |
-| **[DeepSeek](/docs/memori-byodb/llm/deepseek)**       | OpenAI-compatible  | `pip install memori openai`           |
+| Provider                                              | Integration        | Python                                | TypeScript                                          |
+| ----------------------------------------------------- | ------------------ | ------------------------------------- | --------------------------------------------------- |
+| **[OpenAI](/docs/memori-byodb/llm/openai)**           | Direct SDK wrapper | `pip install memori openai`           | `npm install @memorilabs/memori openai`             |
+| **[Anthropic](/docs/memori-byodb/llm/anthropic)**     | Direct SDK wrapper | `pip install memori anthropic`        | `npm install @memorilabs/memori @anthropic-ai/sdk`  |
+| **[Google Gemini](/docs/memori-byodb/llm/gemini)**    | Direct SDK wrapper | `pip install memori google-genai`     | `npm install @memorilabs/memori @google/genai`      |
+| **[Agno](/docs/memori-byodb/llm/agno)**               | Framework support  | `pip install memori agno`             | Coming soon                                         |
+| **[AWS Bedrock](/docs/memori-byodb/llm/aws-bedrock)** | LangChain adapter  | `pip install memori langchain-aws`    | Coming soon                                         |
+| **[DeepSeek](/docs/memori-byodb/llm/deepseek)**       | OpenAI-compatible  | `pip install memori openai`           | Coming soon                                         |
+| **[LangChain](/docs/memori-byodb/llm/langchain)**     | Framework support  | `pip install memori langchain-openai` | Coming soon                                         |
+| **[Nebius AI Studio](/docs/memori-byodb/llm/nebius)** | OpenAI-compatible  | `pip install memori openai`           | Coming soon                                         |
+| **[Pydantic AI](/docs/memori-byodb/llm/pydantic-ai)** | Framework support  | `pip install memori pydantic-ai`      | Coming soon                                         |
+| **[xAI Grok](/docs/memori-byodb/llm/xai-grok)**       | OpenAI-compatible  | `pip install memori openai`           | Coming soon                                         |
 
 All providers support sync, async, streamed, and unstreamed modes.
 
-Any provider with an OpenAI-compatible API works by setting a custom `base_url` — including Nebius AI Studio, DeepSeek, NVIDIA NIM, Azure OpenAI, and more. See [OpenAI-Compatible Providers](#openai-compatible-providers) below.
+Any provider with an OpenAI-compatible API works by setting a custom `base_url` — including Azure OpenAI, DeepSeek, Nebius AI Studio, NVIDIA NIM, and more. See [OpenAI-Compatible Providers](#openai-compatible-providers) below.
 
 ## Pydantic AI
 
@@ -55,7 +55,7 @@ print(result.output)
 
 ## OpenAI-Compatible Providers
 
-Any provider with an OpenAI-compatible API works by setting a custom `base_url`. Examples: xAI, Nebius AI Studio, DeepSeek, Azure OpenAI.
+Any provider with an OpenAI-compatible API works by setting a custom `base_url`. Examples: Azure OpenAI, DeepSeek, Nebius AI Studio, xAI.
 
 ```python
 import os

--- a/docs/memori-byodb/llm/pydantic-ai.mdx
+++ b/docs/memori-byodb/llm/pydantic-ai.mdx
@@ -12,6 +12,7 @@ Memori integrates at the agent level — register the `Agent` instance and Memor
   [app.memorilabs.ai](https://app.memorilabs.ai).
 </Note>
 
+
 ## Quick Start
 
 ```python

--- a/docs/memori-byodb/llm/xai-grok.mdx
+++ b/docs/memori-byodb/llm/xai-grok.mdx
@@ -12,6 +12,7 @@ xAI provides an OpenAI-compatible API. Use the `openai` Python package with `bas
   [app.memorilabs.ai](https://app.memorilabs.ai).
 </Note>
 
+
 ## Quick Start
 
 <CodeGroup title="xAI Grok Integration">

--- a/docs/memori-byodb/support/faq.mdx
+++ b/docs/memori-byodb/support/faq.mdx
@@ -16,31 +16,39 @@ Memori is a memory layer for LLM applications, agents, and copilots. It continuo
 
 ### Memori Cloud vs Memori BYODB?
 
-**Memori Cloud** — managed storage, dashboard UI, just add an API key. **Memori BYODB** — bring your own database, full control. Both use the same Python SDK.
+**Memori Cloud** — managed storage, dashboard UI, just add an API key. **Memori BYODB** — bring your own database, full control. Both use the same SDK (Python and TypeScript).
 
 ### Which databases are supported?
 
-CockroachDB, MariaDB, MongoDB, MySQL, OceanBase, Oracle, PostgreSQL, SQLite, and TiDB. Managed providers like Neon, Supabase, and AWS RDS/Aurora are supported through compatible PostgreSQL/MySQL engines. See the [Database guides](/docs/memori-byodb/databases/overview).
+**Python:** CockroachDB, MariaDB, MongoDB, MySQL, OceanBase, Oracle, PostgreSQL, SQLite, and TiDB. Managed providers like Neon, Supabase, and AWS RDS/Aurora are supported through compatible PostgreSQL/MySQL engines.
+
+**TypeScript:** SQLite, PostgreSQL, and MySQL. AWS RDS/Aurora, CockroachDB, MariaDB, Neon, Supabase, and TiDB work through compatible PostgreSQL/MySQL drivers.
+
+See the [Database guides](/docs/memori-byodb/databases/overview).
 
 ### Do I need SQLAlchemy to use BYODB?
 
-No. SQLAlchemy is one option, but not a requirement. Memori also supports direct DB-API 2.0 connection factories, Django ORM integration, and MongoDB database callables.
+No, SQLAlchemy is one option for Python but not a requirement. Memori also supports direct DB-API 2.0 connection factories, Django ORM integration, and MongoDB database callables. In TypeScript, pass a factory function that returns the connection — `better-sqlite3`, `pg` Pool, or `mysql2` Pool.
 
 ### Which LLM providers and frameworks work?
 
-OpenAI, Anthropic, Google Gemini, xAI Grok, Deepseek, Nebius AI Studio, AWS Bedrock, LangChain, Agno, and Pydantic AI. All support sync, async, and streaming. See the [LLM guides](/docs/memori-byodb/llm/overview).
+**Python:** OpenAI, Anthropic, Google Gemini, Agno, AWS Bedrock, DeepSeek, LangChain, Nebius AI Studio, Pydantic AI, and xAI Grok. All support sync, async, and streaming.
+
+**TypeScript:** OpenAI, Anthropic, and Google Gemini.
+
+See the [LLM guides](/docs/memori-byodb/llm/overview).
 
 ### Do I need a Memori API key?
 
-No. The open-source version works without one. An API key only unlocks higher Advanced Augmentation quotas (100 free without key, 5,000/month with a free key).
+No, the open-source version works without one. An API key only unlocks higher Advanced Augmentation quotas (5,000/month with a free key).
 
 ### Do I need to manage infrastructure?
 
-Yes — you run your own database. For the simplest setup, use SQLite (single file, no server). For production, PostgreSQL is recommended.
+Yes, you run your own database. For the simplest setup, use SQLite (single file, no server). For production, PostgreSQL is recommended.
 
 ### Does it support async?
 
-Yes. All providers support async mode out of the box. Just use your provider's async client.
+Yes, all providers support async mode out of the box. We recommend using your provider's async client.
 
 ### How does augmentation work?
 
@@ -48,11 +56,14 @@ It runs in the background after each conversation and extracts facts, preference
 
 ### Can I use multiple LLM providers?
 
-Yes. Register multiple clients on the same Memori instance. Memories are shared across providers since they're linked to entities, not providers.
+Yes, you can register multiple clients on the same Memori instance. Memories are shared across providers since they're linked to entities, not providers.
 
 ### Can I migrate between Memori Cloud and BYODB?
 
-Yes. Both use the same SDK — just swap `conn=SessionLocal` for `api_key="..."`. Existing local memories don't auto-transfer though.
+Yes, both use the same SDK.<br />
+In Python, swap `conn=SessionLocal` for `api_key="..."`.<br />
+In TypeScript, remove the `conn` option and set `MEMORI_API_KEY`.<br />
+Existing local memories don't auto-transfer.
 
 ### What is `augmentation.wait()`?
 

--- a/docs/memori-byodb/support/troubleshooting.mdx
+++ b/docs/memori-byodb/support/troubleshooting.mdx
@@ -9,14 +9,17 @@ Quick fixes for the most common Memori issues.
 
 ## Installation
 
-**`pip install memori` fails** — Requires Python 3.10+.
+**Python: `pip install memori` fails** — Requires Python 3.10+.
 Run `python --version` to check, then `pip install --upgrade pip && pip install memori`.
 
-**Missing binary deps** — Install prerequisites first: `pip install numpy>=1.24.0 sentence-transformers>=3.0.0 memori`.
+**Python: Missing binary deps** — Install prerequisites first: `pip install numpy>=1.24.0 sentence-transformers>=3.0.0 memori`.
+
+**TypeScript: `npm install @memorilabs/memori` fails** — Requires Node.js 20+.
+Run `node --version` to check.
 
 ## Database Connection
 
-**`No connection factory provided`** — You must pass `conn` when initializing:
+**Python: `No connection factory provided`** — You must pass `conn` when initializing:
 
 ```python
 from sqlalchemy import create_engine
@@ -28,9 +31,21 @@ SessionLocal = sessionmaker(bind=engine)
 mem = Memori(conn=SessionLocal)
 ```
 
-**`Table does not exist`** — Run `mem.config.storage.build()` once after initialization or after upgrading.
+**`Table does not exist`** — Run `build()` once after initialization or after upgrading:
 
-**Connection pool errors** — Enable pre-ping and recycling:
+<CodeGroup title="Build Schema">
+
+```python {{ title: 'Python' }}
+mem.config.storage.build()
+```
+
+```typescript {{ title: 'TypeScript' }}
+await mem.config.storage.build();
+```
+
+</CodeGroup>
+
+**Python: Connection pool errors** — Enable pre-ping and recycling:
 
 ```python
 engine = create_engine("postgresql+psycopg2://user:pass@host/db", pool_pre_ping=True, pool_recycle=300)
@@ -49,45 +64,116 @@ engine = create_engine("postgresql+psycopg2://user:pass@host/db", pool_pre_ping=
 
 1. **Set attribution** before LLM calls — without it, no memories are stored:
 
-```python
+<CodeGroup title="Set Attribution">
+
+```python {{ title: 'Python' }}
 mem.attribution(entity_id="user_123", process_id="my_app")
 ```
 
+```typescript {{ title: 'TypeScript' }}
+mem.attribution('user_123', 'my_app');
+```
+
+</CodeGroup>
+
 2. **Wait for augmentation** in short-lived scripts:
 
-```python
+<CodeGroup title="Wait for Augmentation">
+
+```python {{ title: 'Python' }}
 mem.augmentation.wait()
 ```
 
+```typescript {{ title: 'TypeScript' }}
+await mem.augmentation.wait();
+```
+
+</CodeGroup>
+
 3. **Register your LLM client** — conversations aren't captured without registration:
 
-```python
+<CodeGroup title="Register LLM Client">
+
+```python {{ title: 'Python' }}
 client = OpenAI()
 mem = Memori(conn=SessionLocal).llm.register(client)
 ```
 
+```typescript {{ title: 'TypeScript' }}
+const client = new OpenAI();
+const mem = new Memori({ conn: () => db }).llm.register(client);
+```
+
+</CodeGroup>
+
 ## Recall Returns Empty
 
 - Verify `entity_id` matches what was used when memories were created
-- Wait for augmentation: `mem.augmentation.wait()`
-- Increase limit: `mem.recall("query", limit=10)`
-- Lower threshold: `mem.config.recall_relevance_threshold = 0.05`
+- Wait for augmentation:
+
+<CodeGroup title="Wait for Augmentation">
+
+```python {{ title: 'Python' }}
+mem.augmentation.wait()
+```
+
+```typescript {{ title: 'TypeScript' }}
+await mem.augmentation.wait();
+```
+
+</CodeGroup>
+
+- **Python:** Increase limit: `mem.recall("query", limit=10)`
+- Lower threshold:
+
+<CodeGroup title="Lower Recall Threshold">
+
+```python {{ title: 'Python' }}
+mem.config.recall_relevance_threshold = 0.05
+```
+
+```typescript {{ title: 'TypeScript' }}
+mem.config.recallRelevanceThreshold = 0.05;
+```
+
+</CodeGroup>
 
 ## Quota Exceeded
 
-```
-QuotaExceededError: your IP address is over quota
+<CodeGroup title="Quota Exceeded Error">
+
+```python {{ title: 'Python' }}
+# QuotaExceededError: your IP address is over quota
 ```
 
-Sign up for a free API key at [app.memorilabs.ai](https://app.memorilabs.ai) — gives 5,000/month (vs 100 without a key). Set it via `export MEMORI_API_KEY="your-key"`.
+```typescript {{ title: 'TypeScript' }}
+// QuotaExceededError: Your IP address is over quota; register for an API key now: https://app.memorilabs.ai/signup
+```
+
+</CodeGroup>
+
+Sign up for a free API key at [app.memorilabs.ai](https://app.memorilabs.ai) - gives 5,000/month. Set it via `export MEMORI_API_KEY="your-key"`.
 
 ## Performance
 
-**Slow first run** — Memori downloads the embedding model on first use. Pre-download with `python -m memori setup`.
+**Python: Slow first run** — Memori downloads the embedding model on first use. Pre-download with `python -m memori setup`.
 
-**High memory usage** — Reduce embeddings limit: `mem.config.recall_embeddings_limit = 500`. Use PostgreSQL for production.
+**Python: High memory usage** — Reduce embeddings limit: `mem.config.recall_embeddings_limit = 500`. Use PostgreSQL for production.
 
-**Network timeouts** — Increase timeout: `mem.config.request_secs_timeout = 10` and retries: `mem.config.request_num_backoff = 10`.
+**Network timeouts:**
+
+<CodeGroup title="Network Timeout">
+
+```python {{ title: 'Python' }}
+mem.config.request_secs_timeout = 10
+mem.config.request_num_backoff = 10
+```
+
+```typescript {{ title: 'TypeScript' }}
+mem.config.timeout = 10000; // milliseconds, default 30000
+```
+
+</CodeGroup>
 
 ## Debug Logging
 
@@ -105,4 +191,8 @@ mem = Memori(conn=SessionLocal, debug_truncate=False)
 - [Discord](https://discord.gg/abD4eGym6v)
 - [Examples](https://github.com/MemoriLabs/Memori/tree/main/examples)
 
-Include your Python version, Memori version (`pip show memori`), database type, and full error trace.
+If you need help troubleshooting an issue, please reach out on Discord with more details and we will be happy to assist you.
+
+For Python: include your Python version, Memori version (`pip show memori`), database type, and full error trace.
+
+For TypeScript: include your Node.js version, Memori version (`npm list @memorilabs/memori`), database type, and full error trace.

--- a/docs/memori-cloud/llm/gemini.mdx
+++ b/docs/memori-cloud/llm/gemini.mdx
@@ -5,7 +5,7 @@ description: Using Memori with Google Gemini models on Memori Cloud.
 
 # Google Gemini
 
-Memori integrates with Google Gemini via the `google-genai` SDK. Register the `GenerativeModel` instance and all `generate_content()` calls are automatically captured.
+Memori integrates with Google Gemini via the `google-genai` SDK (Python) and `@google/genai` SDK (TypeScript). Register the client instance and all calls are automatically captured.
 
 ## Quick Start
 
@@ -13,16 +13,18 @@ Memori integrates with Google Gemini via the `google-genai` SDK. Register the `G
 
 ```python {{ title: 'Python' }}
 import os
+from google import genai
 from memori import Memori
-import google.generativeai as genai
 
-genai.configure(api_key=os.getenv("GOOGLE_API_KEY"))
-client = genai.GenerativeModel("gemini-2.0-flash-exp")  # Use any Gemini model
+client = genai.Client(api_key=os.environ["GOOGLE_API_KEY"])
 
 mem = Memori().llm.register(client)
 mem.attribution(entity_id="user_123", process_id="gemini_assistant")
 
-response = client.generate_content("Hello!")
+response = client.models.generate_content(
+    model="gemini-2.5-flash",
+    contents="Hello!"
+)
 print(response.text)
 ```
 
@@ -46,11 +48,11 @@ console.log(response.text);
 
 ## Supported Modes
 
-| Mode         | Python                                  | TypeScript                                      |
-| ------------ | --------------------------------------- | ----------------------------------------------- |
-| **Sync**     | `client.generate_content()`             | —                                               |
-| **Async**    | `await client.generate_content_async()` | `await client.models.generateContent()`         |
-| **Streamed** | `stream=True` parameter                 | `client.models.generateContentStream()`         |
+| Mode         | Python                                              | TypeScript                                        |
+| ------------ | --------------------------------------------------- | ------------------------------------------------- |
+| **Sync**     | `client.models.generate_content()`                  | —                                                 |
+| **Async**    | `await client.aio.models.generate_content()`        | `await client.models.generateContent()`           |
+| **Streamed** | `client.models.generate_content_stream()`           | `await client.models.generateContentStream()`     |
 
 ## Additional Modes
 
@@ -58,17 +60,19 @@ console.log(response.text);
 
 ```python
 import os, asyncio
+from google import genai
 from memori import Memori
-import google.generativeai as genai
 
-genai.configure(api_key=os.getenv("GOOGLE_API_KEY"))
-client = genai.GenerativeModel("gemini-2.0-flash-exp")  # Use any Gemini model
+client = genai.Client(api_key=os.environ["GOOGLE_API_KEY"])
 
 mem = Memori().llm.register(client)
 mem.attribution(entity_id="user_123", process_id="gemini_assistant")
 
 async def main():
-    response = await client.generate_content_async("Hello!")
+    response = await client.aio.models.generate_content(
+        model="gemini-2.5-flash",
+        contents="Hello!"
+    )
     print(response.text)
 
 asyncio.run(main())
@@ -80,17 +84,18 @@ asyncio.run(main())
 
 ```python {{ title: 'Python' }}
 import os
+from google import genai
 from memori import Memori
-import google.generativeai as genai
 
-genai.configure(api_key=os.getenv("GOOGLE_API_KEY"))
-client = genai.GenerativeModel("gemini-2.0-flash-exp")  # Use any Gemini model
+client = genai.Client(api_key=os.environ["GOOGLE_API_KEY"])
 
 mem = Memori().llm.register(client)
 mem.attribution(entity_id="user_123", process_id="gemini_assistant")
 
-response = client.generate_content("Hello!", stream=True)
-for chunk in response:
+for chunk in client.models.generate_content_stream(
+    model="gemini-2.5-flash",
+    contents="Hello!"
+):
     print(chunk.text, end="")
 ```
 
@@ -116,22 +121,29 @@ for await (const chunk of stream) {
 
 ## Multi-Turn Conversations
 
-Use `start_chat()` for multi-turn interactions. Memori tracks the full conversation automatically.
+Pass a message history as the `contents` array. Memori tracks the full conversation automatically.
 
-```python
-chat = client.start_chat()
-response = chat.send_message("My name is Alice.")
+<CodeGroup title="Multi-Turn">
+
+```python {{ title: 'Python' }}
+response = client.models.generate_content(
+    model="gemini-2.5-flash",
+    contents="My name is Alice."
+)
 print(response.text)
 
-response = chat.send_message("What's my name?")
-print(response.text)
+response2 = client.models.generate_content(
+    model="gemini-2.5-flash",
+    contents=[
+        {"role": "user", "parts": [{"text": "My name is Alice."}]},
+        {"role": "model", "parts": [{"text": response.text}]},
+        {"role": "user", "parts": [{"text": "What's my name?"}]},
+    ]
+)
+print(response2.text)
 ```
 
-### TypeScript
-
-Multi-turn conversations in TypeScript use the standard messages array pattern:
-
-```typescript
+```typescript {{ title: 'TypeScript' }}
 import { GoogleGenAI } from '@google/genai';
 import { Memori } from '@memorilabs/memori';
 
@@ -158,3 +170,5 @@ const response2 = await client.models.generateContent({
 });
 console.log(response2.text);
 ```
+
+</CodeGroup>

--- a/docs/memori-cloud/llm/langchain.mdx
+++ b/docs/memori-cloud/llm/langchain.mdx
@@ -5,7 +5,7 @@ description: Using Memori with LangChain chat models on Memori Cloud.
 
 # LangChain
 
-Memori Cloud supports any LangChain chat model. Each class has its own registration keyword: `ChatOpenAI` for OpenAI, `ChatAnthropic` for Anthropic, `ChatBedrock` for BedRock, `ChatGoogleGenerativeAI` for Google Gen AI models.
+Memori Cloud supports LangChain chat models. Each class has its own registration keyword: `ChatOpenAI` for OpenAI, `ChatBedrock` for AWS Bedrock, `ChatGoogleGenerativeAI` for Google Gen AI models.
 
 <Note>
   TypeScript support for LangChain is coming soon. The TypeScript SDK currently supports [OpenAI](/docs/memori-cloud/llm/openai), [Anthropic](/docs/memori-cloud/llm/anthropic), and [Gemini](/docs/memori-cloud/llm/gemini).
@@ -65,19 +65,10 @@ for chunk in client.stream("Hello!"):
 | Package                  | Chat Model               | Registration Keyword     |
 | ------------------------ | ------------------------ | ------------------------ |
 | `langchain-openai`       | `ChatOpenAI`             | `chatopenai=client`      |
-| `langchain-anthropic`    | `ChatAnthropic`          | `chatanthropic=client`   |
 | `langchain-google-genai` | `ChatGoogleGenerativeAI` | `chatgooglegenai=client` |
 | `langchain-aws`          | `ChatBedrock`            | `chatbedrock=client`     |
 
 <CodeGroup title="LangChain Providers">
-
-```python {{ title: 'Anthropic' }}
-from langchain_anthropic import ChatAnthropic
-from memori import Memori
-
-client = ChatAnthropic(model="claude-sonnet-4-5-20250929")
-mem = Memori().llm.register(chatopenai=client)
-```
 
 ```python {{ title: 'Google Gemini' }}
 from langchain_google_genai import ChatGoogleGenerativeAI

--- a/docs/memori-cloud/llm/overview.mdx
+++ b/docs/memori-cloud/llm/overview.mdx
@@ -14,13 +14,13 @@ Memori Cloud works with all major LLM providers and frameworks. Register any sup
 | **[OpenAI](/docs/memori-cloud/llm/openai)**           | Direct SDK wrapper | `pip install memori openai`           | `npm install @memorilabs/memori openai`              |
 | **[Anthropic](/docs/memori-cloud/llm/anthropic)**     | Direct SDK wrapper | `pip install memori anthropic`        | `npm install @memorilabs/memori @anthropic-ai/sdk`   |
 | **[Google Gemini](/docs/memori-cloud/llm/gemini)**    | Direct SDK wrapper | `pip install memori google-genai`     | `npm install @memorilabs/memori @google/genai`       |
-| **[xAI Grok](/docs/memori-cloud/llm/xai-grok)**       | OpenAI-compatible  | `pip install memori openai`           | Coming soon                                         |
-| **[Nebius AI Studio](/docs/memori-cloud/llm/nebius)** | OpenAI-compatible  | `pip install memori openai`           | Coming soon                                         |
-| **[DeepSeek](/docs/memori-cloud/llm/deepseek)**       | OpenAI-compatible  | `pip install memori openai`           | Coming soon                                         |
-| **[AWS Bedrock](/docs/memori-cloud/llm/aws-bedrock)** | LangChain adapter  | `pip install memori langchain-aws`    | Coming soon                                         |
-| **[LangChain](/docs/memori-cloud/llm/langchain)**     | Framework support  | `pip install memori langchain-openai` | Coming soon                                         |
 | **[Agno](/docs/memori-cloud/llm/agno)**               | Framework support  | `pip install memori agno`             | Coming soon                                         |
+| **[AWS Bedrock](/docs/memori-cloud/llm/aws-bedrock)** | LangChain adapter  | `pip install memori langchain-aws`    | Coming soon                                         |
+| **[DeepSeek](/docs/memori-cloud/llm/deepseek)**       | OpenAI-compatible  | `pip install memori openai`           | Coming soon                                         |
+| **[LangChain](/docs/memori-cloud/llm/langchain)**     | Framework support  | `pip install memori langchain-openai` | Coming soon                                         |
+| **[Nebius AI Studio](/docs/memori-cloud/llm/nebius)** | OpenAI-compatible  | `pip install memori openai`           | Coming soon                                         |
 | **[Pydantic AI](/docs/memori-cloud/llm/pydantic-ai)** | Framework support  | `pip install memori pydantic-ai`      | Coming soon                                         |
+| **[xAI Grok](/docs/memori-cloud/llm/xai-grok)**       | OpenAI-compatible  | `pip install memori openai`           | Coming soon                                         |
 
 All providers support sync, async, streamed, and unstreamed modes.
 

--- a/docs/memori-cloud/support/faq.mdx
+++ b/docs/memori-cloud/support/faq.mdx
@@ -11,15 +11,16 @@ __Memori__ is a memory layer for LLM applications, agents, and copilots. It cont
 
 ## Which languages are supported?
 
-Memori Cloud supports both **Python** and **TypeScript** SDKs. The Python SDK (`memori`) works with both Memori Cloud and BYODB. The TypeScript SDK (`@memorilabs/memori`) is currently Cloud-only. Both SDKs support OpenAI, Anthropic, and Gemini, with additional provider support in Python.
+Memori offers official **Python** and **TypeScript** SDKs, both compatible with Memori Cloud and BYODB. OpenAI, Anthropic, and Google Gemini are supported in both languages, with a broader set of LLM providers and frameworks available in Python.
 
 ## Memori Cloud vs Memori BYODB?
 
-**Memori Cloud** — managed storage, dashboard UI, just add an API key. Available for Python and TypeScript. **Memori BYODB** — bring your own database & maintain full control. Available for Python and TypeScript.
+**Memori Cloud** — managed storage, dashboard UI, just add an API key.<br />
+**Memori BYODB** — bring your own database & maintain full control.
 
 ## Which LLM providers and frameworks are supported?
 
-**Python:** OpenAI, Anthropic, Google Gemini, xAI Grok, Deepseek, Nebius AI Studio, AWS Bedrock, LangChain, Agno, and Pydantic AI. All support sync, async, and streaming.
+**Python:** OpenAI, Anthropic, Google Gemini, Agno, AWS Bedrock, DeepSeek, LangChain, Nebius AI Studio, Pydantic AI, and xAI Grok. All support sync, async, and streaming.
 
 **TypeScript:** OpenAI, Anthropic, and Google Gemini. More providers coming soon.
 
@@ -27,11 +28,11 @@ See the [Integration Overview](/docs/memori-cloud/llm/overview).
 
 ## Do I need to set up a database?
 
-No. The Memori Cloud platform manages all storage. Just initialize with `mem = Memori()`.
+No, the Memori Cloud platform manages all storage. We recommend initializing with `mem = Memori()`.
 
 ## Is there a free tier?
 
-Yes. 5000 memory read & writes per month. Sign up at [app.memorilabs.ai](https://app.memorilabs.ai).
+Yes, you can create 5,000 memories and recall 15,000 memories per month with a free API key. Sign up on [app.memorilabs.ai](https://app.memorilabs.ai)
 
 ## What counts as a "memory"?
 
@@ -39,7 +40,8 @@ Each fact, preference, or relationship extracted by Advanced Augmentation counts
 
 ## Does it support async?
 
-Yes. In Python, use your provider's async client (e.g. `AsyncOpenAI`). TypeScript is natively async — all SDK calls return Promises.
+Yes, in Python, use your provider's async client (e.g. `AsyncOpenAI`).<br />
+TypeScript is natively async — LLM calls and `recall()` return Promises.
 
 ## How does augmentation work?
 
@@ -47,11 +49,14 @@ It runs in the background after each conversation and extracts facts, preference
 
 ## Can I use multiple LLM providers?
 
-Yes. Register multiple clients on the same Memori instance. Memories are shared across providers since they're scoped to entities, not to providers.
+Yes, you can register multiple clients on the same Memori instance. Memories are shared across providers since they're scoped to entities, not to providers.
 
 ## Can I migrate between Memori Cloud and Memori BYODB?
 
-Yes. In Python, both use the same SDK — just remove `conn=SessionLocal` for Memori Cloud or add it for Memori BYODB. Existing memories don't auto-transfer. The TypeScript SDK is Cloud-only.
+Yes, both use the same SDK.<br />
+In Python, remove `conn=SessionLocal` for Memori Cloud or add it for Memori BYODB.<br />
+In TypeScript, remove the `conn` option and set `MEMORI_API_KEY` for Cloud, or pass `conn: () => db` for BYODB.<br />
+Existing memories don't auto-transfer.
 
 ## Still have questions?
 

--- a/docs/memori-cloud/support/troubleshooting.mdx
+++ b/docs/memori-cloud/support/troubleshooting.mdx
@@ -16,7 +16,7 @@ Run `python --version` to check, then `pip install --upgrade pip && pip install 
 
 ### TypeScript
 
-**If `npm install @memorilabs/memori` fails** — Requires Node.js 18+.
+**If `npm install @memorilabs/memori` fails** — Requires Node.js 20+.
 Run `node --version` to check, then update Node.js and retry.
 
 **Module resolution errors** — Ensure your `tsconfig.json` uses `"moduleResolution": "node"` or `"bundler"`. The SDK ships ESM with TypeScript declarations.
@@ -77,22 +77,13 @@ mem.attribution('user_123', 'my_app');
 
 Enable debug logging to inspect request flow, attribution, and augmentation behavior when troubleshooting missing memories or API errors. Use it temporarily in development, since logs can include sensitive request metadata.
 
-<CodeGroup title="Debug Logging">
-
-```python {{ title: 'Python' }}
+```python
 import logging
 logging.basicConfig(level=logging.DEBUG, format="%(asctime)s | %(name)s | %(levelname)s | %(message)s")
 
 from memori import Memori
 mem = Memori()
 ```
-
-```typescript {{ title: 'TypeScript' }}
-import { Memori } from '@memorilabs/memori';
-const mem = new Memori({ debug: true });
-```
-
-</CodeGroup>
 
 ## Getting Help
 


### PR DESCRIPTION
All changes were verified against the Python and TypeScript SDK source code.

BYODB

contribute/overview.mdx
Split bug report version details into separate Python and TypeScript lines

llm/overview.mdx
Replaced — with "Coming soon" for Python-only providers. Reordered providers alphabetically

support/faq.mdx
Added TypeScript throughout: databases and LLM providers split by SDK, migration instructions for both Python and TypeScript, and SQLAlchemy answer updated with the TypeScript equivalent

support/troubleshooting.mdx
Added full TypeScript support using CodeGroup tabs throughout. All TypeScript API details verified against SDK source


Cloud

llm/gemini.mdx
Revised the Python examples to use the correct google-genai SDK. Replaced google.generativeai / GenerativeModel with genai.Client, client.models.generate_content(), client.aio.models.generate_content() (async), and client.models.generate_content_stream() (streaming). The old API fails Memori's runtime client check

llm/langchain.mdx
Removed ChatAnthropic / chatanthropic=client from the providers table — that keyword does not exist in the Python SDK. Fixed the intro sentence and removed the broken Anthropic code tab

llm/overview.mdx
Reordered providers alphabetically after these main LLMs (OpenAI, Anthropic, Google Gemini): Agno, AWS Bedrock, DeepSeek, LangChain, Nebius AI Studio, Pydantic AI, xAI Grok

support/faq.mdx
Fixed incorrect claim that the TypeScript SDK is cloud only, as it supports BYODB via conn. Added line breaks, fixed Yes/No punctuation, updated free tier wording, and reordered Python LLM providers alphabetically

support/troubleshooting.mdx
Fixed Node.js requirement 18+ → 20+. Removed invalid new Memori({ debug: true }) TypeScript example — debug is not a valid MemoriOptions property. Removed the TypeScript debug logging tab as no debug logging mechanism exists in the TS SDK