### PR TITLE
Fixed widen _request_headers return type

### DIFF
--- a/memori/embeddings/_tei.py
+++ b/memori/embeddings/_tei.py
@@ -21,8 +21,8 @@ class TEI:
     timeout: int | None = 30
     headers: dict[str, str] | None = None
 
-    def _request_headers(self) -> dict[str, str]:
-        base = {"Content-Type": "application/json"}
+    def _request_headers(self) -> dict[str, str | bytes]:
+        base: dict[str, str | bytes] = {"Content-Type": "application/json"}
         if self.headers:
             base.update(self.headers)
         return base


### PR DESCRIPTION
Fixed a pre-existing type check failure in memori/embeddings/_tei.py that was blocking staging deployment.

The _request_headers() method returned dict[str, str], but requests.post() expects MutableMapping[str, str | bytes].

Since dict is invariant in its value type, dict[str, str] is not assignable to MutableMapping[str, str | bytes], causing ty to raise an error.

Widened the return type annotation to dict[str, str | bytes] and explicitly typed the base variable to match. Runtime behavior is unchanged and all values remain strings.