### PR TITLE
fix(skills): restrict recall filters to valid source/signal pairs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ google-credentials.json
 *.key
 
 AGENTS.md
+.codex/skills/
 
 tests/examples/*
 

--- a/docs/memori-cloud/hermes/agent-skills.md
+++ b/docs/memori-cloud/hermes/agent-skills.md
@@ -75,17 +75,28 @@ Supported parameters:
 - `project_id`: project or workspace context
 - `session_id`: specific session, only with `project_id`
 - `date_start` / `date_end`: UTC time-bounded recall
-- `source`: type of memory
-- `signal`: how the memory was derived
+- `source`: type of memory (must be paired with `signal` from the allowed combinations below)
+- `signal`: how the memory was derived (must be paired with `source` from the allowed combinations below)
 
 If a `session_id` is provided, a `project_id` must also be provided. All timestamps are stored in UTC.
 
-Memory filters:
+Allowed source + signal combinations:
 
-- `source`: `constraint`, `decision`, `execution`, `fact`, `insight`, `instruction`, `status`, `strategy`, `task`
-- `signal`: `commit`, `discovery`, `failure`, `inference`, `pattern`, `result`, `update`, `verification`
+`source` and `signal` are not independent. They must be set together (or both omitted). Only the following `(source, signal)` pairs are valid:
 
-Use `source` and `signal` to prioritize high-signal memory when possible.
+- `source=constraint`, `signal=discovery`
+- `source=decision`, `signal=commit`
+- `source=fact`, `signal=verification`
+- `source=execution`, `signal=failure`
+- `source=instruction`, `signal=discovery`
+- `source=insight`, `signal=inference`
+- `source=status`, `signal=update`
+- `source=strategy`, `signal=pattern`
+- `source=task`, `signal=result`
+
+Any combination of `source` and `signal` not in this list is invalid and must not be sent to `memori_recall`.
+
+Use one of the allowed `(source, signal)` pairs to prioritize high-signal memory when possible; never set `source` or `signal` independently.
 
 Default behavior:
 
@@ -95,7 +106,7 @@ Best practices:
 
 - Start narrow with the configured project scope.
 - Add time bounds only when needed.
-- Use `source` and `signal` to refine results.
+- Use an allowed `(source, signal)` pair to refine results (never set them independently).
 - Expand scope only if needed.
 - Do not recall on every turn.
 

--- a/docs/memori-cloud/hermes/agent-skills.md
+++ b/docs/memori-cloud/hermes/agent-skills.md
@@ -34,7 +34,7 @@ Use it to understand:
 
 ## Quick Reference
 
-- `memori_recall`: retrieve precise memories by query, project, session, time range, source, or signal.
+- `memori_recall`: retrieve precise memories by query, project, session, time range, or an allowed source/signal pair.
 - `memori_recall_summary`: retrieve a state summary for session starts, daily briefs, or broad status checks.
 - `memori_feedback`: report irrelevant, missing, stale, or especially useful memory behavior.
 - `memori_signup`: create a Memori account or request an API key when the user explicitly asks.

--- a/docs/memori-cloud/openclaw/agent-skills.md
+++ b/docs/memori-cloud/openclaw/agent-skills.md
@@ -57,36 +57,29 @@ Prefer targeted recall over broad queries.
 - `projectId` → project or workspace context
 - `sessionId` → specific session
 - `dateStart` / `dateEnd` → time-bounded recall
-- `source` → type of memory
-- `signal` → how the memory was derived
+- `source` → type of memory (must be paired with `signal` from the allowed combinations below)
+- `signal` → how the memory was derived (must be paired with `source` from the allowed combinations below)
 
 > Note: If a `sessionId` is provided, a `projectId` must also be provided.
 > All timestamps are stored in **UTC**.
 
-### Memory filters
+### Allowed source + signal combinations
 
-- `source`:
-  - constraint
-  - decision
-  - execution
-  - fact
-  - insight
-  - instruction
-  - status
-  - strategy
-  - task
+`source` and `signal` are not independent. They must be set together (or both omitted). Only the following `(source, signal)` pairs are valid:
 
-- `signal`:
-  - commit
-  - discovery
-  - failure
-  - inference
-  - pattern
-  - result
-  - update
-  - verification
+- `source=constraint`, `signal=discovery`
+- `source=decision`, `signal=commit`
+- `source=fact`, `signal=verification`
+- `source=execution`, `signal=failure`
+- `source=instruction`, `signal=discovery`
+- `source=insight`, `signal=inference`
+- `source=status`, `signal=update`
+- `source=strategy`, `signal=pattern`
+- `source=task`, `signal=result`
 
-Use `source` and `signal` to prioritize high-signal memory when possible.
+Any combination of `source` and `signal` not in this list is invalid and must not be sent to `memori_recall`.
+
+Use one of the allowed `(source, signal)` pairs to prioritize high-signal memory when possible; never set `source` or `signal` independently.
 
 ### Default behavior (recall)
 
@@ -97,7 +90,7 @@ Use `source` and `signal` to prioritize high-signal memory when possible.
 
 - Start narrow (entity + project)
 - Add time bounds only when needed
-- Use `source` and `signal` to refine results
+- Use an allowed `(source, signal)` pair to refine results (never set them independently)
 - Expand scope only if needed
 - Do not recall on every turn
 

--- a/docs/memori-cloud/openclaw/overview.mdx
+++ b/docs/memori-cloud/openclaw/overview.mdx
@@ -133,28 +133,21 @@ Supported parameters:
 - `source`
 - `signal`
 
-#### Memory classification schema:
+#### Memory classification schema (allowed source + signal combinations):
 
-**Sources**
-- constraint
-- decision
-- execution
-- fact
-- insight
-- instruction
-- status
-- strategy
-- task
+`source` and `signal` are not independent. They must be set together (or both omitted). Only the following `(source, signal)` pairs are valid:
 
-**Signals**
-- commit
-- discovery
-- failure
-- inference
-- pattern
-- result
-- update
-- verification
+- `source=constraint`, `signal=discovery`
+- `source=decision`, `signal=commit`
+- `source=fact`, `signal=verification`
+- `source=execution`, `signal=failure`
+- `source=instruction`, `signal=discovery`
+- `source=insight`, `signal=inference`
+- `source=status`, `signal=update`
+- `source=strategy`, `signal=pattern`
+- `source=task`, `signal=result`
+
+Any combination of `source` and `signal` not in this list is invalid and must not be sent to `memori_recall`.
 
 #### Default behavior:
 

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -110,30 +110,21 @@ This allows agents to retrieve the most relevant facts, decisions, constraints, 
 
 **Supported parameters:** `entity_id`, `project_id`, `session_id`, `date_start`, `date_end`, `source`, `signal`
 
-**Memory classification schema**
+**Memory classification schema (allowed source + signal combinations)**
 
-*Sources*
+`source` and `signal` are not independent. They must be set together (or both omitted). Only the following `(source, signal)` pairs are valid:
 
-- `constraint`
-- `decision`
-- `execution`
-- `fact`
-- `insight`
-- `instruction`
-- `status`
-- `strategy`
-- `task`
+- `source=constraint`, `signal=discovery`
+- `source=decision`, `signal=commit`
+- `source=fact`, `signal=verification`
+- `source=execution`, `signal=failure`
+- `source=instruction`, `signal=discovery`
+- `source=insight`, `signal=inference`
+- `source=status`, `signal=update`
+- `source=strategy`, `signal=pattern`
+- `source=task`, `signal=result`
 
-*Signals*
-
-- `commit`
-- `discovery`
-- `failure`
-- `inference`
-- `pattern`
-- `result`
-- `update`
-- `verification`
+Any combination of `source` and `signal` not in this list is invalid and must not be sent to `memori_recall`.
 
 **Default behavior:** If no date range is provided, recall returns all-time memories.
 

--- a/integrations/openclaw/package-lock.json
+++ b/integrations/openclaw/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memorilabs/openclaw-memori",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorilabs/openclaw-memori",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@memorilabs/memori": "0.1.12-beta"

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorilabs/openclaw-memori",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Official MemoriLabs.ai long-term memory plugin for OpenClaw",
   "type": "module",
   "main": "./dist/index.js",

--- a/integrations/openclaw/skills/memori/SKILL.md
+++ b/integrations/openclaw/skills/memori/SKILL.md
@@ -57,36 +57,29 @@ Prefer targeted recall over broad queries.
 - `projectId` → project or workspace context
 - `sessionId` → specific session
 - `dateStart` / `dateEnd` → time-bounded recall
-- `source` → type of memory
-- `signal` → how the memory was derived
+- `source` → type of memory (must be paired with `signal` from the allowed combinations below)
+- `signal` → how the memory was derived (must be paired with `source` from the allowed combinations below)
 
 > Note: If a `sessionId` is provided, a `projectId` must also be provided.
 > All timestamps are stored in **UTC**.
 
-### Memory filters
+### Allowed source + signal combinations
 
-- `source`:
-  - constraint
-  - decision
-  - execution
-  - fact
-  - insight
-  - instruction
-  - status
-  - strategy
-  - task
+`source` and `signal` are not independent. They must be set together (or both omitted). Only the following `(source, signal)` pairs are valid:
 
-- `signal`:
-  - commit
-  - discovery
-  - failure
-  - inference
-  - pattern
-  - result
-  - update
-  - verification
+- `source=constraint`, `signal=discovery`
+- `source=decision`, `signal=commit`
+- `source=fact`, `signal=verification`
+- `source=execution`, `signal=failure`
+- `source=instruction`, `signal=discovery`
+- `source=insight`, `signal=inference`
+- `source=status`, `signal=update`
+- `source=strategy`, `signal=pattern`
+- `source=task`, `signal=result`
 
-Use `source` and `signal` to prioritize high-signal memory when possible.
+Any combination of `source` and `signal` not in this list is invalid and must not be sent to `memori_recall`.
+
+Use one of the allowed `(source, signal)` pairs to prioritize high-signal memory when possible; never set `source` or `signal` independently.
 
 ### Default behavior (recall)
 
@@ -97,7 +90,7 @@ Use `source` and `signal` to prioritize high-signal memory when possible.
 
 - Start narrow (entity + project)
 - Add time bounds only when needed
-- Use `source` and `signal` to refine results
+- Use an allowed `(source, signal)` pair to refine results (never set them independently)
 - Expand scope only if needed
 - Do not recall on every turn
 

--- a/integrations/openclaw/src/tools/memori-recall.ts
+++ b/integrations/openclaw/src/tools/memori-recall.ts
@@ -93,7 +93,9 @@ export function createMemoriRecallTool(deps: ToolDeps) {
         const hasSource = finalParams.source != null;
         const hasSignal = finalParams.signal != null;
         if (hasSource !== hasSignal) {
-          const errorResult = { error: 'source and signal must be provided together or both omitted' };
+          const errorResult = {
+            error: 'source and signal must be provided together or both omitted',
+          };
           logger.warn(`memori_recall rejected: ${JSON.stringify(errorResult)}`);
           return {
             content: [{ type: 'text' as const, text: JSON.stringify(errorResult) }],
@@ -112,10 +114,10 @@ export function createMemoriRecallTool(deps: ToolDeps) {
           strategy: 'pattern',
           task: 'result',
         };
-        if (hasSource && VALID_PAIRS[finalParams.source!] !== finalParams.signal) {
-
+        const source = finalParams.source;
+        if (hasSource && source != null && VALID_PAIRS[source] !== finalParams.signal) {
           const errorResult = {
-            error: `Invalid (source, signal) pair: (${finalParams.source}, ${finalParams.signal}). Expected signal for source "${finalParams.source}" is "${VALID_PAIRS[finalParams.source!]}".`,
+            error: `Invalid (source, signal) pair: (${source}, ${finalParams.signal}). Expected signal for source "${source}" is "${VALID_PAIRS[source]}".`,
           };
           logger.warn(`memori_recall rejected: ${JSON.stringify(errorResult)}`);
           return {

--- a/integrations/openclaw/src/tools/memori-recall.ts
+++ b/integrations/openclaw/src/tools/memori-recall.ts
@@ -33,7 +33,8 @@ export function createMemoriRecallTool(deps: ToolDeps) {
         },
         signal: {
           type: 'string',
-          description: 'Filter to a specific fact signal. MUST be one of the allowed enum values.',
+          description:
+            'Filter by how the memory was derived. MUST be set together with `source` using one of the allowed (source, signal) pairs — never set independently. Valid pairs: (constraint, discovery), (decision, commit), (fact, verification), (execution, failure), (instruction, discovery), (insight, inference), (status, update), (strategy, pattern), (task, result).',
           enum: [
             'commit',
             'discovery',
@@ -48,7 +49,7 @@ export function createMemoriRecallTool(deps: ToolDeps) {
         source: {
           type: 'string',
           description:
-            'Filter to a specific source origin. MUST be one of the allowed enum values.',
+            'Filter by memory type. MUST be set together with `signal` using one of the allowed (source, signal) pairs — never set independently. Valid pairs: (constraint, discovery), (decision, commit), (fact, verification), (execution, failure), (instruction, discovery), (insight, inference), (status, update), (strategy, pattern), (task, result).',
           enum: [
             'constraint',
             'decision',
@@ -82,6 +83,40 @@ export function createMemoriRecallTool(deps: ToolDeps) {
 
         if (finalParams.sessionId && !finalParams.projectId) {
           const errorResult = { error: 'sessionId cannot be provided without projectId' };
+          logger.warn(`memori_recall rejected: ${JSON.stringify(errorResult)}`);
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify(errorResult) }],
+            details: null,
+          };
+        }
+
+        const hasSource = finalParams.source != null;
+        const hasSignal = finalParams.signal != null;
+        if (hasSource !== hasSignal) {
+          const errorResult = { error: 'source and signal must be provided together or both omitted' };
+          logger.warn(`memori_recall rejected: ${JSON.stringify(errorResult)}`);
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify(errorResult) }],
+            details: null,
+          };
+        }
+
+        const VALID_PAIRS: Record<string, string> = {
+          constraint: 'discovery',
+          decision: 'commit',
+          fact: 'verification',
+          execution: 'failure',
+          instruction: 'discovery',
+          insight: 'inference',
+          status: 'update',
+          strategy: 'pattern',
+          task: 'result',
+        };
+        if (hasSource && VALID_PAIRS[finalParams.source!] !== finalParams.signal) {
+
+          const errorResult = {
+            error: `Invalid (source, signal) pair: (${finalParams.source}, ${finalParams.signal}). Expected signal for source "${finalParams.source}" is "${VALID_PAIRS[finalParams.source!]}".`,
+          };
           logger.warn(`memori_recall rejected: ${JSON.stringify(errorResult)}`);
           return {
             content: [{ type: 'text' as const, text: JSON.stringify(errorResult) }],

--- a/integrations/openclaw/tests/tools/memori-recall.test.ts
+++ b/integrations/openclaw/tests/tools/memori-recall.test.ts
@@ -56,8 +56,8 @@ describe('tools/memori-recall', () => {
         dateEnd: '2024-12-31',
         projectId: 'proj-1',
         sessionId: 'sess-1',
-        signal: 'user',
-        source: 'chat',
+        source: 'fact',
+        signal: 'verification',
       });
 
       expect(createRecallClient).toHaveBeenCalledWith('test-key', 'test-entity');
@@ -71,8 +71,8 @@ describe('tools/memori-recall', () => {
         dateStart: '2024-01-01',
         dateEnd: '2024-12-31',
         sessionId: 'sess-1',
-        signal: 'user',
-        source: 'chat',
+        source: 'fact',
+        signal: 'verification',
       });
 
       const client = vi.mocked(createRecallClient).mock.results[0].value;
@@ -90,8 +90,8 @@ describe('tools/memori-recall', () => {
         dateEnd: '2024-12-31',
         projectId: 'override-project',
         sessionId: 'sess-1',
-        signal: 'user',
-        source: 'chat',
+        source: 'fact',
+        signal: 'verification',
       });
 
       const client = vi.mocked(createRecallClient).mock.results[0].value;
@@ -109,8 +109,8 @@ describe('tools/memori-recall', () => {
         dateEnd: '2024-12-31',
         projectId: 'proj-1',
         sessionId: 'sess-1',
-        signal: 'user',
-        source: 'chat',
+        source: 'fact',
+        signal: 'verification',
       });
 
       const client = vi.mocked(createRecallClient).mock.results[0].value;
@@ -120,8 +120,8 @@ describe('tools/memori-recall', () => {
           dateEnd: '2024-12-31',
           projectId: 'proj-1',
           sessionId: 'sess-1',
-          signal: 'user',
-          source: 'chat',
+          source: 'fact',
+          signal: 'verification',
         })
       );
     });
@@ -139,8 +139,8 @@ describe('tools/memori-recall', () => {
         dateEnd: '2024-12-31',
         projectId: 'proj-1',
         sessionId: 'sess-1',
-        signal: 'user',
-        source: 'chat',
+        source: 'fact',
+        signal: 'verification',
       });
 
       expect(result.content).toHaveLength(1);
@@ -163,8 +163,8 @@ describe('tools/memori-recall', () => {
         dateEnd: '2024-12-31',
         projectId: 'proj-1',
         sessionId: 'sess-1',
-        signal: 'user',
-        source: 'chat',
+        source: 'fact',
+        signal: 'verification',
       });
 
       expect(JSON.parse(result.content[0].text)).toEqual({ error: 'Recall failed' });
@@ -209,13 +209,90 @@ describe('tools/memori-recall', () => {
         dateEnd: '2024-12-31',
         projectId: 'proj-1',
         sessionId: 'sess-1',
-        signal: 'user',
-        source: 'chat',
+        source: 'fact',
+        signal: 'verification',
       });
 
       expect(deps.logger.info).toHaveBeenCalledWith(
         expect.stringContaining('memori_recall params')
       );
+    });
+
+    describe('source/signal validation', () => {
+      it('should reject source provided without signal', async () => {
+        const tool = createMemoriRecallTool(deps);
+
+        const result = await tool.execute('call-1', { source: 'fact' });
+
+        expect(JSON.parse(result.content[0].text)).toEqual({
+          error: 'source and signal must be provided together or both omitted',
+        });
+        expect(deps.logger.warn).toHaveBeenCalledWith(
+          expect.stringContaining('memori_recall rejected')
+        );
+      });
+
+      it('should reject signal provided without source', async () => {
+        const tool = createMemoriRecallTool(deps);
+
+        const result = await tool.execute('call-1', { signal: 'verification' });
+
+        expect(JSON.parse(result.content[0].text)).toEqual({
+          error: 'source and signal must be provided together or both omitted',
+        });
+        expect(deps.logger.warn).toHaveBeenCalledWith(
+          expect.stringContaining('memori_recall rejected')
+        );
+      });
+
+      it('should reject an invalid (source, signal) pair', async () => {
+        const tool = createMemoriRecallTool(deps);
+
+        const result = await tool.execute('call-1', { source: 'fact', signal: 'commit' });
+
+        const parsed = JSON.parse(result.content[0].text);
+        expect(parsed.error).toMatch(/Invalid \(source, signal\) pair/);
+        expect(parsed.error).toContain('fact');
+        expect(parsed.error).toContain('commit');
+        expect(parsed.error).toContain('verification');
+        expect(deps.logger.warn).toHaveBeenCalledWith(
+          expect.stringContaining('memori_recall rejected')
+        );
+      });
+
+      it('should succeed when both source and signal are omitted', async () => {
+        const { createRecallClient } = await import('../../src/utils/memori-client.js');
+        const tool = createMemoriRecallTool(deps);
+
+        const result = await tool.execute('call-1', { projectId: 'proj-1' });
+
+        const client = vi.mocked(createRecallClient).mock.results[0].value;
+        expect(client.agentRecall).toHaveBeenCalled();
+        expect(JSON.parse(result.content[0].text)).not.toHaveProperty('error');
+      });
+
+      it.each([
+        ['constraint', 'discovery'],
+        ['decision', 'commit'],
+        ['fact', 'verification'],
+        ['execution', 'failure'],
+        ['instruction', 'discovery'],
+        ['insight', 'inference'],
+        ['status', 'update'],
+        ['strategy', 'pattern'],
+        ['task', 'result'],
+      ])('should accept valid pair (%s, %s)', async (source, signal) => {
+        const { createRecallClient } = await import('../../src/utils/memori-client.js');
+        const tool = createMemoriRecallTool(deps);
+
+        const result = await tool.execute('call-1', { source, signal });
+
+        const client = vi.mocked(createRecallClient).mock.results[0].value;
+        expect(client.agentRecall).toHaveBeenCalledWith(
+          expect.objectContaining({ source, signal })
+        );
+        expect(JSON.parse(result.content[0].text)).not.toHaveProperty('error');
+      });
     });
   });
 });


### PR DESCRIPTION
Updates OpenClaw and Hermes skill/docs to clarify that `source` and `signal` in `memori_recall` are not independent filters. They must be set together (or both omitted), and only a fixed set of `(source, signal)` pairs is valid. Each skill/doc now lists the allowed combinations and explicitly states that any other combination is invalid.

Affected files:

- `docs/memori-cloud/hermes/agent-skills.md`
- `docs/memori-cloud/openclaw/agent-skills.md`
- `docs/memori-cloud/openclaw/overview.mdx`
- `integrations/hermes/README.md`
- `integrations/openclaw/skills/memori/SKILL.md`


## Notes for reviewers

Pure documentation/skill update. The allowed pairs documented here mirror the classification schema enforced server-side; the goal is to prevent agents from sending arbitrary `source`/`signal` combinations to `memori_recall`.