### PR TITLE
feat(sdk): add agentCompaction support for GET /v1/agent/compaction

### DIFF
--- a/memori-ts/package-lock.json
+++ b/memori-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memorilabs/memori",
-  "version": "0.1.20-beta",
+  "version": "0.1.21-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorilabs/memori",
-      "version": "0.1.20-beta",
+      "version": "0.1.21-beta",
       "license": "Apache-2.0",
       "dependencies": {
         "@memorilabs/axon": "^0.1.5"

--- a/memori-ts/package.json
+++ b/memori-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorilabs/memori",
-  "version": "0.1.20-beta",
+  "version": "0.1.21-beta",
   "description": "The official TypeScript SDK for Memori",
   "type": "module",
   "main": "./dist/index.js",

--- a/memori-ts/src/engines/recall.ts
+++ b/memori-ts/src/engines/recall.ts
@@ -12,6 +12,8 @@ import {
   stringifyContent,
 } from '../utils/utils.js';
 import {
+  AgentCompactionParams,
+  AgentCompactionResponse,
   AgentRecallParams,
   AgentRecallResponse,
   AgentRecallSummaryParams,
@@ -133,6 +135,34 @@ export class RecallEngine {
     });
 
     return this.api.get<AgentRecallSummaryResponse>(`agent/recall/summary${qs}`);
+  }
+
+  /**
+   * Fetches a structured compaction of the agent's long-term memory and context
+   * from GET /v1/agent/compaction. Project ID defaults to the current project context.
+   * Session ID must be explicitly provided and requires a project ID to be present.
+   */
+  public async agentCompaction(
+    params: AgentCompactionParams = {}
+  ): Promise<AgentCompactionResponse> {
+    const projectId = params.projectId ?? this.project.id;
+    const sessionId = params.sessionId;
+
+    if (!projectId) {
+      throw new Error('projectId is required for agent compaction');
+    }
+
+    if (sessionId && !projectId) {
+      throw new Error('sessionId cannot be provided without projectId');
+    }
+
+    const qs = this.buildQueryString({
+      project_id: projectId,
+      session_id: sessionId,
+      num_messages: params.numMessages,
+    });
+
+    return this.api.get<AgentCompactionResponse>(`agent/compaction${qs}`);
   }
 
   private buildQueryString(

--- a/memori-ts/src/engines/recall.ts
+++ b/memori-ts/src/engines/recall.ts
@@ -145,7 +145,7 @@ export class RecallEngine {
   public async agentCompaction(
     params: AgentCompactionParams = {}
   ): Promise<AgentCompactionResponse> {
-    const projectId = params.projectId ?? this.project.id;
+    const projectId = params.projectId;
     const sessionId = params.sessionId;
 
     if (!projectId) {

--- a/memori-ts/src/engines/recall.ts
+++ b/memori-ts/src/engines/recall.ts
@@ -145,7 +145,7 @@ export class RecallEngine {
   public async agentCompaction(
     params: AgentCompactionParams = {}
   ): Promise<AgentCompactionResponse> {
-    const projectId = params.projectId;
+    const projectId = params.projectId ?? this.project.id;
     const sessionId = params.sessionId;
 
     if (!projectId) {

--- a/memori-ts/src/index.ts
+++ b/memori-ts/src/index.ts
@@ -1,3 +1,11 @@
 export { Memori } from './memori.js';
-export { ParsedFact } from './types/api.js';
+export {
+  AgentCompactionParams,
+  AgentCompactionResponse,
+  CompactionContinuation,
+  CompactionMessage,
+  CompactionMetadata,
+  CompactionState,
+  ParsedFact,
+} from './types/api.js';
 export * from './core/errors.js';

--- a/memori-ts/src/integrations/base.ts
+++ b/memori-ts/src/integrations/base.ts
@@ -1,6 +1,8 @@
 import { LLMRequest, LLMResponse, CallContext } from '@memorilabs/axon';
 import { MemoriCore, IntegrationRequest } from '../types/integrations.js';
 import {
+  AgentCompactionParams,
+  AgentCompactionResponse,
   AgentRecallParams,
   AgentRecallResponse,
   AgentRecallSummaryParams,
@@ -155,6 +157,24 @@ export abstract class BaseIntegration {
     } catch (e) {
       console.warn('Memori Integration Recall failed:', e);
       return undefined;
+    }
+  }
+
+  /**
+   * Internal helper: Fetches a structured compaction of the agent's memory and context.
+   *
+   * @param params - projectId (defaults to project context), sessionId and numMessages optional
+   * @returns Compaction response, or null on failure
+   * @internal
+   */
+  protected async executeAgentCompaction(
+    params: AgentCompactionParams
+  ): Promise<AgentCompactionResponse | null> {
+    try {
+      return await this.core.recall.agentCompaction(params);
+    } catch (e) {
+      console.warn('Memori Agent Compaction failed:', e);
+      return null;
     }
   }
 

--- a/memori-ts/src/integrations/openclaw.ts
+++ b/memori-ts/src/integrations/openclaw.ts
@@ -1,5 +1,7 @@
 import { IntegrationRequest } from 'src/types/integrations.js';
 import {
+  AgentCompactionParams,
+  AgentCompactionResponse,
   AgentRecallParams,
   AgentRecallResponse,
   AgentRecallSummaryParams,
@@ -90,6 +92,22 @@ export class OpenClawIntegration extends BaseIntegration {
     params?: AgentRecallSummaryParams
   ): Promise<AgentRecallSummaryResponse> {
     return this.executeAgentRecallSummary(params);
+  }
+
+  /**
+   * Fetches a structured compaction of the agent's long-term memory and context.
+   * Returns active tasks, open loops, environment variables, standing orders, and
+   * recent message history in a single consolidated snapshot.
+   *
+   * @param params - projectId (defaults to current project context), sessionId and numMessages optional
+   * @returns Compaction response, or null on failure
+   *
+   * @throws Does not throw - errors are logged but swallowed to prevent disrupting the agent
+   */
+  public async agentCompaction(
+    params?: AgentCompactionParams
+  ): Promise<AgentCompactionResponse | null> {
+    return this.executeAgentCompaction(params ?? {});
   }
 
   /**

--- a/memori-ts/src/types/api.ts
+++ b/memori-ts/src/types/api.ts
@@ -173,3 +173,63 @@ export interface AgentRecallResponse {
 export interface AgentRecallSummaryResponse {
   summaries?: RecallSummary[];
 }
+
+/**
+ * Filter parameters for the agent compaction endpoint (GET /v1/agent/compaction).
+ * If sessionId is provided, projectId must also be provided.
+ */
+export interface AgentCompactionParams {
+  /** The external ID of the project to compact. Defaults to the current project context. */
+  projectId?: string;
+  /** The external ID of a specific agent session to scope the compaction to. */
+  sessionId?: string;
+  /** Number of recent conversation messages to include in the result. Defaults to 5. */
+  numMessages?: number;
+}
+
+/** Continuation hints indicating what the agent last did and what it should do next. */
+export interface CompactionContinuation {
+  last_action: string;
+  next_expected_action: string;
+}
+
+/** A single message from the agent's recent conversation history. */
+export interface CompactionMessage {
+  content: string;
+  role: string;
+  trace?: unknown;
+  type: string;
+}
+
+/** Metadata describing when and how the compaction was generated. */
+export interface CompactionMetadata {
+  date: {
+    execution: string;
+  };
+  filter: {
+    project: { id: string };
+    session?: { id: string };
+  };
+}
+
+/** The structured state of ongoing work captured at compaction time. */
+export interface CompactionState {
+  active_tasks: string[];
+  open_loops: string[];
+  pending_results: string[];
+}
+
+/**
+ * Response from the agent compaction endpoint (GET /v1/agent/compaction).
+ * Contains a consolidated snapshot of the agent's long-term memory and context.
+ */
+export interface AgentCompactionResponse {
+  continuation: CompactionContinuation;
+  environment: string[];
+  messages: CompactionMessage[];
+  metadata: CompactionMetadata;
+  standing_orders: string[];
+  state: CompactionState;
+  timeline?: string;
+  workspace_changes: string[];
+}

--- a/memori-ts/tests/engines/recall.test.ts
+++ b/memori-ts/tests/engines/recall.test.ts
@@ -350,6 +350,87 @@ describe('RecallEngine', () => {
     });
   });
 
+  describe('agentCompaction()', () => {
+    const mockCompactionResponse = {
+      continuation: { last_action: 'completed task A', next_expected_action: 'start task B' },
+      environment: ['NODE_ENV=production'],
+      messages: [{ content: 'hello', role: 'user', type: 'text' }],
+      metadata: {
+        date: { execution: '2024-01-01T00:00:00.000Z' },
+        filter: { project: { id: 'test-project-id' } },
+      },
+      standing_orders: ['always format code before committing'],
+      state: {
+        active_tasks: ['refactor auth module'],
+        open_loops: ['waiting for DB migration approval'],
+        pending_results: [],
+      },
+      workspace_changes: ['src/auth/index.ts updated'],
+    };
+
+    it('calls GET agent/compaction with the correct route', async () => {
+      (mockApi.get as any).mockResolvedValue(mockCompactionResponse);
+      await recallEngine.agentCompaction({ projectId: 'proj-1' });
+      expect(mockApi.get).toHaveBeenCalledWith(expect.stringContaining('agent/compaction'));
+    });
+
+    it('includes project_id in the query string', async () => {
+      (mockApi.get as any).mockResolvedValue(mockCompactionResponse);
+      await recallEngine.agentCompaction({ projectId: 'proj-1' });
+      const url: string = (mockApi.get as any).mock.calls[0][0];
+      expect(url).toContain('project_id=proj-1');
+    });
+
+    it('defaults projectId to the current project context when not supplied', async () => {
+      (mockApi.get as any).mockResolvedValue(mockCompactionResponse);
+      await recallEngine.agentCompaction();
+      const url: string = (mockApi.get as any).mock.calls[0][0];
+      expect(url).toContain('project_id=test-project-id');
+    });
+
+    it('includes session_id in the query string when provided', async () => {
+      (mockApi.get as any).mockResolvedValue(mockCompactionResponse);
+      await recallEngine.agentCompaction({ projectId: 'proj-1', sessionId: 'sess-1' });
+      const url: string = (mockApi.get as any).mock.calls[0][0];
+      expect(url).toContain('session_id=sess-1');
+    });
+
+    it('includes num_messages in the query string when provided', async () => {
+      (mockApi.get as any).mockResolvedValue(mockCompactionResponse);
+      await recallEngine.agentCompaction({ projectId: 'proj-1', numMessages: 10 });
+      const url: string = (mockApi.get as any).mock.calls[0][0];
+      expect(url).toContain('num_messages=10');
+    });
+
+    it('omits num_messages from the query string when not provided', async () => {
+      (mockApi.get as any).mockResolvedValue(mockCompactionResponse);
+      await recallEngine.agentCompaction({ projectId: 'proj-1' });
+      const url: string = (mockApi.get as any).mock.calls[0][0];
+      expect(url).not.toContain('num_messages=');
+    });
+
+    it('returns the full compaction response', async () => {
+      (mockApi.get as any).mockResolvedValue(mockCompactionResponse);
+      const result = await recallEngine.agentCompaction({ projectId: 'proj-1' });
+      expect(result).toEqual(mockCompactionResponse);
+    });
+
+    it('throws when projectId is absent from both params and project context', async () => {
+      (mockProject as any).id = undefined;
+      await expect(recallEngine.agentCompaction()).rejects.toThrow(
+        'projectId is required for agent compaction'
+      );
+      (mockProject as any).id = 'test-project-id';
+    });
+
+    it('accepts an explicit projectId override', async () => {
+      (mockApi.get as any).mockResolvedValue(mockCompactionResponse);
+      await recallEngine.agentCompaction({ projectId: 'override-proj' });
+      const url: string = (mockApi.get as any).mock.calls[0][0];
+      expect(url).toContain('project_id=override-proj');
+    });
+  });
+
   describe('recall() — local storage path error handling', () => {
     it('returns [] and warns when local retrieval throws', async () => {
       (mockNativeEngine as any).hasStorage = true;

--- a/memori-ts/tests/engines/recall.test.ts
+++ b/memori-ts/tests/engines/recall.test.ts
@@ -381,11 +381,11 @@ describe('RecallEngine', () => {
       expect(url).toContain('project_id=proj-1');
     });
 
-    it('should throw an error if projectId is not provided', async () => {
+    it('defaults projectId to the current project context when not supplied', async () => {
       (mockApi.get as any).mockResolvedValue(mockCompactionResponse);
-      await expect(recallEngine.agentCompaction()).rejects.toThrow(
-        'projectId is required for agent compaction'
-      );
+      await recallEngine.agentCompaction();
+      const url: string = (mockApi.get as any).mock.calls[0][0];
+      expect(url).toContain('project_id=test-project-id');
     });
 
     it('includes session_id in the query string when provided', async () => {

--- a/memori-ts/tests/engines/recall.test.ts
+++ b/memori-ts/tests/engines/recall.test.ts
@@ -381,11 +381,11 @@ describe('RecallEngine', () => {
       expect(url).toContain('project_id=proj-1');
     });
 
-    it('defaults projectId to the current project context when not supplied', async () => {
+    it('should throw an error if projectId is not provided', async () => {
       (mockApi.get as any).mockResolvedValue(mockCompactionResponse);
-      await recallEngine.agentCompaction();
-      const url: string = (mockApi.get as any).mock.calls[0][0];
-      expect(url).toContain('project_id=test-project-id');
+      await expect(recallEngine.agentCompaction()).rejects.toThrow(
+        'projectId is required for agent compaction'
+      );
     });
 
     it('includes session_id in the query string when provided', async () => {

--- a/memori-ts/tests/integrations/base.test.ts
+++ b/memori-ts/tests/integrations/base.test.ts
@@ -14,6 +14,18 @@ class TestIntegration extends BaseIntegration {
   public testAgentFeedback(content: string) {
     return this.executeAgentFeedback(content);
   }
+  public testAgentAugmentation(req: IntegrationRequest) {
+    return this.executeAgentAugmentation(req);
+  }
+  public testAgentRecall(params?: Parameters<typeof this.executeAgentRecall>[0]) {
+    return this.executeAgentRecall(params);
+  }
+  public testAgentRecallSummary(params?: Parameters<typeof this.executeAgentRecallSummary>[0]) {
+    return this.executeAgentRecallSummary(params);
+  }
+  public testAgentCompaction(params: Parameters<typeof this.executeAgentCompaction>[0]) {
+    return this.executeAgentCompaction(params);
+  }
 }
 
 describe('BaseIntegration', () => {
@@ -23,9 +35,14 @@ describe('BaseIntegration', () => {
 
   beforeEach(() => {
     mockCore = {
-      recall: { handleRecall: vi.fn() },
+      recall: {
+        handleRecall: vi.fn(),
+        agentRecall: vi.fn(),
+        agentRecallSummary: vi.fn(),
+        agentCompaction: vi.fn(),
+      },
       persistence: { handlePersistence: vi.fn() },
-      augmentation: { handleAugmentation: vi.fn() },
+      augmentation: { handleAugmentation: vi.fn(), handleAgentAugmentation: vi.fn() },
       config: { entityId: 'test-user', processId: 'test-process' },
       session: { id: 'test-session-id' },
       project: { id: 'test-project-id', set: vi.fn() },
@@ -189,6 +206,156 @@ describe('BaseIntegration', () => {
 
       expect(consoleWarnSpy).toHaveBeenCalledWith(
         'Memori Agent Feedback failed:',
+        expect.any(Error)
+      );
+    });
+  });
+
+  describe('executeAgentAugmentation()', () => {
+    const req: IntegrationRequest = {
+      userMessage: { role: 'user', content: 'hello bot', type: 'text' },
+      agentResponse: { role: 'assistant', content: 'hello human', type: 'text' },
+      trace: { tools: [{ name: 'search', args: { query: 'hello' }, result: 'found' }] },
+    };
+
+    it('should silently abort if no session ID is present', async () => {
+      (mockCore.session as any).id = undefined;
+
+      await integration.testAgentAugmentation(req);
+
+      expect(mockCore.persistence.handlePersistence).not.toHaveBeenCalled();
+      expect(mockCore.augmentation.handleAgentAugmentation).not.toHaveBeenCalled();
+    });
+
+    it('should call handlePersistence and handleAgentAugmentation with correct payloads', async () => {
+      await integration.testAgentAugmentation(req);
+
+      expect(mockCore.persistence.handlePersistence).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messages: [{ role: 'user', content: 'hello bot', type: 'text' }],
+        }),
+        expect.objectContaining({ content: 'hello human', type: 'text' }),
+        expect.objectContaining({ traceId: expect.stringContaining('integration-trace-') })
+      );
+      expect(mockCore.augmentation.handleAgentAugmentation).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        req.trace,
+        req.summary
+      );
+    });
+
+    it('should swallow errors and log a warning if engines fail', async () => {
+      (mockCore.persistence.handlePersistence as any).mockRejectedValue(
+        new Error('Persistence failed')
+      );
+
+      await expect(integration.testAgentAugmentation(req)).resolves.toBeUndefined();
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'Memori Integration Capture failed:',
+        expect.any(Error)
+      );
+    });
+  });
+
+  describe('executeAgentRecall()', () => {
+    it('should delegate to core.recall.agentRecall and return the result', async () => {
+      const mockResult = { facts: [{ id: 1, content: 'memory' }] };
+      (mockCore.recall.agentRecall as any).mockResolvedValue(mockResult);
+
+      const result = await integration.testAgentRecall({ projectId: 'proj-1' });
+
+      expect(mockCore.recall.agentRecall).toHaveBeenCalledWith({ projectId: 'proj-1' });
+      expect(result).toEqual(mockResult);
+    });
+
+    it('should return an empty object and log a warning when agentRecall throws', async () => {
+      (mockCore.recall.agentRecall as any).mockRejectedValue(new Error('API error'));
+
+      const result = await integration.testAgentRecall({ projectId: 'proj-1' });
+
+      expect(result).toEqual({});
+      expect(consoleWarnSpy).toHaveBeenCalledWith('Memori Agent Recall failed:', expect.any(Error));
+    });
+  });
+
+  describe('executeAgentRecallSummary()', () => {
+    it('should delegate to core.recall.agentRecallSummary and return the result', async () => {
+      const mockResult = {
+        summaries: [
+          { content: 'summary', date_created: '2024-01-01', entity_fact_id: 1, fact_id: 1 },
+        ],
+      };
+      (mockCore.recall.agentRecallSummary as any).mockResolvedValue(mockResult);
+
+      const result = await integration.testAgentRecallSummary({ projectId: 'proj-1' });
+
+      expect(mockCore.recall.agentRecallSummary).toHaveBeenCalledWith({ projectId: 'proj-1' });
+      expect(result).toEqual(mockResult);
+    });
+
+    it('should return an empty object and log a warning when agentRecallSummary throws', async () => {
+      (mockCore.recall.agentRecallSummary as any).mockRejectedValue(new Error('API error'));
+
+      const result = await integration.testAgentRecallSummary();
+
+      expect(result).toEqual({});
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'Memori Agent Recall Summary failed:',
+        expect.any(Error)
+      );
+    });
+  });
+
+  describe('executeAgentCompaction()', () => {
+    const mockCompactionResponse = {
+      continuation: { last_action: 'ran tests', next_expected_action: 'open PR' },
+      environment: ['CI=true'],
+      messages: [{ content: 'hi', role: 'user', type: 'text' }],
+      metadata: {
+        date: { execution: '2024-06-01T00:00:00.000Z' },
+        filter: { project: { id: 'proj-1' } },
+      },
+      standing_orders: ['prefer small commits'],
+      state: { active_tasks: ['auth refactor'], open_loops: [], pending_results: [] },
+      workspace_changes: [],
+    };
+
+    it('should delegate to core.recall.agentCompaction and return the result', async () => {
+      (mockCore.recall.agentCompaction as any).mockResolvedValue(mockCompactionResponse);
+
+      const result = await integration.testAgentCompaction({ projectId: 'proj-1' });
+
+      expect(mockCore.recall.agentCompaction).toHaveBeenCalledWith({ projectId: 'proj-1' });
+      expect(result).toEqual(mockCompactionResponse);
+    });
+
+    it('should forward sessionId and numMessages params', async () => {
+      (mockCore.recall.agentCompaction as any).mockResolvedValue(mockCompactionResponse);
+
+      await integration.testAgentCompaction({
+        projectId: 'proj-1',
+        sessionId: 'sess-1',
+        numMessages: 10,
+      });
+
+      expect(mockCore.recall.agentCompaction).toHaveBeenCalledWith({
+        projectId: 'proj-1',
+        sessionId: 'sess-1',
+        numMessages: 10,
+      });
+    });
+
+    it('should return null and log a warning when agentCompaction throws', async () => {
+      (mockCore.recall.agentCompaction as any).mockRejectedValue(new Error('API error'));
+
+      const result = await integration.testAgentCompaction({ projectId: 'proj-1' });
+
+      expect(result).toBeNull();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'Memori Agent Compaction failed:',
         expect.any(Error)
       );
     });

--- a/memori-ts/tests/integrations/openclaw.test.ts
+++ b/memori-ts/tests/integrations/openclaw.test.ts
@@ -97,4 +97,106 @@ describe('OpenClawIntegration', () => {
       expect(spy).toHaveBeenCalledWith('this is great');
     });
   });
+
+  describe('agentRecall()', () => {
+    it('should delegate to executeAgentRecall and return the result', async () => {
+      const mockResult = { facts: [{ id: 1, content: 'a memory' }] };
+      const spy = vi.spyOn(openclaw as any, 'executeAgentRecall').mockResolvedValue(mockResult);
+
+      const result = await openclaw.agentRecall({ projectId: 'proj-1' });
+
+      expect(spy).toHaveBeenCalledWith({ projectId: 'proj-1' });
+      expect(result).toEqual(mockResult);
+    });
+
+    it('should work when called with no params', async () => {
+      const spy = vi.spyOn(openclaw as any, 'executeAgentRecall').mockResolvedValue({});
+
+      await openclaw.agentRecall();
+
+      expect(spy).toHaveBeenCalledWith(undefined);
+    });
+  });
+
+  describe('agentRecallSummary()', () => {
+    it('should delegate to executeAgentRecallSummary and return the result', async () => {
+      const mockResult = {
+        summaries: [{ content: 'sum', date_created: '2024-01-01', entity_fact_id: 1, fact_id: 1 }],
+      };
+      const spy = vi
+        .spyOn(openclaw as any, 'executeAgentRecallSummary')
+        .mockResolvedValue(mockResult);
+
+      const result = await openclaw.agentRecallSummary({ projectId: 'proj-1' });
+
+      expect(spy).toHaveBeenCalledWith({ projectId: 'proj-1' });
+      expect(result).toEqual(mockResult);
+    });
+
+    it('should work when called with no params', async () => {
+      const spy = vi.spyOn(openclaw as any, 'executeAgentRecallSummary').mockResolvedValue({});
+
+      await openclaw.agentRecallSummary();
+
+      expect(spy).toHaveBeenCalledWith(undefined);
+    });
+  });
+
+  describe('agentCompaction()', () => {
+    const mockCompactionResponse = {
+      continuation: { last_action: 'ran tests', next_expected_action: 'open PR' },
+      environment: ['CI=true'],
+      messages: [{ content: 'hi', role: 'user', type: 'text' }],
+      metadata: {
+        date: { execution: '2024-06-01T00:00:00.000Z' },
+        filter: { project: { id: 'proj-1' } },
+      },
+      standing_orders: ['prefer small commits'],
+      state: { active_tasks: ['auth refactor'], open_loops: [], pending_results: [] },
+      workspace_changes: [],
+    };
+
+    it('should delegate to executeAgentCompaction and return the result', async () => {
+      const spy = vi
+        .spyOn(openclaw as any, 'executeAgentCompaction')
+        .mockResolvedValue(mockCompactionResponse);
+
+      const result = await openclaw.agentCompaction({ projectId: 'proj-1' });
+
+      expect(spy).toHaveBeenCalledWith({ projectId: 'proj-1' });
+      expect(result).toEqual(mockCompactionResponse);
+    });
+
+    it('should pass an empty object when called with no params', async () => {
+      const spy = vi
+        .spyOn(openclaw as any, 'executeAgentCompaction')
+        .mockResolvedValue(mockCompactionResponse);
+
+      await openclaw.agentCompaction();
+
+      expect(spy).toHaveBeenCalledWith({});
+    });
+
+    it('should forward all optional params', async () => {
+      const spy = vi
+        .spyOn(openclaw as any, 'executeAgentCompaction')
+        .mockResolvedValue(mockCompactionResponse);
+
+      await openclaw.agentCompaction({ projectId: 'proj-1', sessionId: 'sess-1', numMessages: 15 });
+
+      expect(spy).toHaveBeenCalledWith({
+        projectId: 'proj-1',
+        sessionId: 'sess-1',
+        numMessages: 15,
+      });
+    });
+
+    it('should return null when executeAgentCompaction returns null', async () => {
+      vi.spyOn(openclaw as any, 'executeAgentCompaction').mockResolvedValue(null);
+
+      const result = await openclaw.agentCompaction({ projectId: 'proj-1' });
+
+      expect(result).toBeNull();
+    });
+  });
 });

--- a/memori-ts/vitest.config.ts
+++ b/memori-ts/vitest.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
     include: isIntegration ? ['tests/integrations/**/*.test.ts'] : ['tests/**/*.test.ts'],
     exclude: isIntegration
       ? ['node_modules/', 'dist/']
-      : ['node_modules/', 'dist/', 'tests/integrations/**'],
+      : ['node_modules/', 'dist/', 'tests/integrations/cloud/**'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

- Adds full SDK support for the `GET /v1/agent/compaction` endpoint, which returns a consolidated snapshot of an agent's long-term memory state (active tasks, open loops, standing orders, environment, recent messages, and continuation hints)
- Wires the new method through the full call stack: `RecallEngine` → `BaseIntegration` → `OpenClawIntegration`
- Exports all six new compaction types from the package root
- Fixes a latent coverage gap where `tests/integrations/base.test.ts` and `tests/integrations/openclaw.test.ts` were silently excluded from normal test runs due to an overly broad vitest exclude pattern

## Changes

**`src/types/api.ts`**
Added `AgentCompactionParams`, `AgentCompactionResponse`, `CompactionContinuation`, `CompactionMessage`, `CompactionMetadata`, and `CompactionState` — fully typed against the `GET /v1/agent/compaction` response schema.

**`src/engines/recall.ts`**
Added `RecallEngine.agentCompaction()`. Defaults `projectId` to the current project context (consistent with `agentRecall`), throws if no project ID can be resolved, and serializes all three query params (`project_id`, `session_id`, `num_messages`) through the existing `buildQueryString` helper.

**`src/integrations/base.ts`**
Added `executeAgentCompaction()` protected helper — delegates to `RecallEngine.agentCompaction`, returns `null` and warns on failure (consistent with the other `execute*` helpers).

**`src/integrations/openclaw.ts`**
Added `agentCompaction()` public method delegating to `executeAgentCompaction`. Does not throw.

**`src/index.ts`**
Exported all six new compaction types.

**`vitest.config.ts`**
Changed the unit-test exclude from `tests/integrations/**` → `tests/integrations/cloud/**`. The broader pattern was incorrectly excluding `base.test.ts` and `openclaw.test.ts`, which are pure unit tests with no live-API dependency. The cloud tests self-skip via `describe.runIf(hasKeys)` and don't need the exclusion.

## Tests

- **`tests/engines/recall.test.ts`**: 9 new cases covering route, query-string params, project-context defaulting, `projectId` override, missing-`projectId` error, and full response shape
- **`tests/integrations/base.test.ts`**: added `executeAgentAugmentation`, `executeAgentRecall`, `executeAgentRecallSummary`, and `executeAgentCompaction` suites (previously zero coverage because the file was excluded from the test run)
- **`tests/integrations/openclaw.test.ts`**: added `agentRecall`, `agentRecallSummary`, and `agentCompaction` suites