### PR TITLE
Added compaction updates and consistency improvements

### DIFF
--- a/docs/memori-cloud/hermes/agent-skills.md
+++ b/docs/memori-cloud/hermes/agent-skills.md
@@ -13,7 +13,7 @@ prerequisites:
   pip: [memori]
 ---
 
-# Memori Memory
+# Memori skills file
 
 ## Overview
 

--- a/docs/memori-cloud/openclaw/agent-skills.md
+++ b/docs/memori-cloud/openclaw/agent-skills.md
@@ -20,6 +20,17 @@ Treat `SKILL.md` as a source of truth for what you can do before taking action.
 
 ---
 
+## Quick Reference
+
+- `memori_recall`: retrieve precise memories by query, project, session, time range, or an allowed source/signal pair.
+- `memori_recall_summary`: retrieve a state summary for session starts, daily briefs, or broad status checks.
+- `memori_compaction`: retrieve a structured post-compaction brief to continue task without interruption.
+- `memori_feedback`: report irrelevant, missing, stale, or especially useful memory behavior.
+- `memori_signup`: create a Memori account or request an API key when the user explicitly asks.
+- `memori_quota`: check usage, quota, storage, or memory capacity when the user asks or limits appear to be reached.
+
+---
+
 ## When to use Memori
 
 Use Memori when:

--- a/docs/memori-cloud/openclaw/overview.mdx
+++ b/docs/memori-cloud/openclaw/overview.mdx
@@ -18,7 +18,7 @@ OpenClaw ships with a basic memory layer, but it has fundamental limitations tha
 | Limitation | What happens |
 | --- | --- |
 | **Flat markdown files** | Memory lives in plain text files with no structure or relationships. The agent reads and writes large chunks of text with no way to index, query, or deduplicate facts. |
-| **Context compaction** | As sessions grow longer, important details begin to disappear. Memory gets lost when context is compressed to stay within token limits. |
+| **Context compaction** | When Memori is not installed, as sessions grow longer, important details begin to disappear. Memory gets lost when context is compressed to stay within token limits. Memori addresses this with post-compaction briefs that restore working state after compaction. |
 | **No relationship reasoning** | OpenClaw retrieves semantically similar text, but cannot understand relationships between facts or connect them to each other. |
 | **Weak daily briefs** | Daily summaries are shallow and lossy, missing key decisions, constraints, and patterns from prior sessions. |
 | **Cross-project noise** | When working across multiple projects, memories are not isolated. Searches return irrelevant results from other contexts, polluting the agent's responses. |
@@ -244,7 +244,7 @@ This runs in the background and **never blocks the agent's response**.
 
 ### 2. Agent-Controlled Intelligent Recall (plugin tools)
 
-Memori does not automatically inject memory. The agent retrieves it explicitly.
+Memori does not automatically inject memory into the prompt. The agent retrieves only the context it needs, keeping token usage efficient.
 
 Available tools:
 
@@ -253,6 +253,9 @@ Available tools:
 
 - **`memori_recall_summary`**
   Retrieve summaries and the daily brief
+
+- **`memori_compaction`**
+  Retrieve a structured post-compaction brief to restore working state after context compaction
 
 - **`memori_feedback`**
   Report on memory quality to improve the system
@@ -265,6 +268,7 @@ Memori returns:
 
 - High-signal structured memory
 - Rolling summaries and daily briefs
+- Post-compaction briefs for restoring working state after context compaction
 - Context scoped by entity, project, session, and time
 
 This keeps context:


### PR DESCRIPTION
Improved the Hermes and OpenClaw docs

- Renamed Hermes agent-skills title from 'Memori Memory' to 'Memori skills file'
- Added Quick Reference section to OpenClaw agent-skills to match Hermes
- Added memori_compaction to OpenClaw overview tools list and retrieval model
- Updated context compaction limitation row to note Memori's solution