### PR TITLE
fix(ts): lazy-load native engine

### DIFF
--- a/memori-ts/package-lock.json
+++ b/memori-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memorilabs/memori",
-  "version": "0.1.21-beta",
+  "version": "0.1.22-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorilabs/memori",
-      "version": "0.1.21-beta",
+      "version": "0.1.22-beta",
       "license": "Apache-2.0",
       "dependencies": {
         "@memorilabs/axon": "^0.1.5"

--- a/memori-ts/package.json
+++ b/memori-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorilabs/memori",
-  "version": "0.1.21-beta",
+  "version": "0.1.22-beta",
   "description": "The official TypeScript SDK for Memori",
   "type": "module",
   "main": "./dist/index.js",

--- a/memori-ts/src/core/engine.ts
+++ b/memori-ts/src/core/engine.ts
@@ -1,4 +1,5 @@
-import { MemoriEngine } from '../native/index.js';
+import type { MemoriEngine } from '../native/index.js';
+import { createRequire } from 'node:module';
 import {
   StorageBridge,
   WriteBatch,
@@ -115,7 +116,16 @@ export class NativeEngine {
 
   private getEngine(): MemoriEngine {
     if (!this.memoriEngine) {
-      this.memoriEngine = new MemoriEngine(
+      const require = createRequire(import.meta.url);
+      const native = require('../native/index.js') as {
+        MemoriEngine: new (
+          modelName: string | null,
+          fetchEmbeddings: BridgeCb,
+          fetchFacts: BridgeCb,
+          writeBatch: BridgeCb
+        ) => MemoriEngine;
+      };
+      this.memoriEngine = new native.MemoriEngine(
         this.modelName,
         this.fetchEmbeddingsCb,
         this.fetchFactsCb,

--- a/memori-ts/tests/setup.ts
+++ b/memori-ts/tests/setup.ts
@@ -1,10 +1,12 @@
 import { vi } from 'vitest';
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-/**
- * Unit tests must not load the real `.node` binary (Rust toolchain not required).
- * Integration tests that need the real engine should use a separate setup or unmock.
- */
-vi.mock('../src/native/index.js', () => {
+// vi.hoisted ensures the mock objects exist before vi.mock factories and before imports run.
+// This gives us a single shared MemoriEngine vi.fn() instance that both the ESM import
+// (test file) and the createRequire path (engine.ts lazy load) refer to.
+const { mockNativeModule } = vi.hoisted(() => {
   const stub = () => ({
     retrieve: vi.fn().mockResolvedValue([]),
     recall: vi.fn().mockResolvedValue(''),
@@ -17,7 +19,26 @@ vi.mock('../src/native/index.js', () => {
     resolveWriteCallback: vi.fn(),
   });
 
-  return {
-    MemoriEngine: vi.fn().mockImplementation(stub),
-  };
+  return { mockNativeModule: { MemoriEngine: vi.fn().mockImplementation(stub) } };
 });
+
+/**
+ * Unit tests must not load the real `.node` binary (Rust toolchain not required).
+ * Integration tests that need the real engine should use a separate setup or unmock.
+ */
+vi.mock('../src/native/index.js', () => mockNativeModule);
+
+// engine.ts uses createRequire() (CJS) to lazily load the native module, which bypasses
+// vitest's ESM mock system. Pre-populate Node's require.cache at the resolved absolute path
+// so that any createRequire(url)('../native/index.js') call returns the same mock.
+const _nativePath = resolve(dirname(fileURLToPath(import.meta.url)), '../src/native/index.js');
+const _req = createRequire(import.meta.url);
+(_req.cache as Record<string, unknown>)[_nativePath] = {
+  id: _nativePath,
+  filename: _nativePath,
+  loaded: true,
+  exports: mockNativeModule,
+  parent: null,
+  children: [],
+  paths: [],
+};


### PR DESCRIPTION
Bump package version to 0.1.22-beta. Change engine.ts to import the native engine type-only and lazily load the actual native module via createRequire with a typed wrapper, so the real .node binary is not loaded during unit tests. Update tests/setup.ts to use vi.hoisted to create a shared mockNativeModule, mock the ESM import, and pre-populate Node's require.cache so createRequire resolves the same mock. These changes ensure unit tests use the mock native engine and avoid loading the native binary.

## What does this PR do?

<!-- Describe the purpose of this change and the problem it solves. -->

## Related issue

<!-- Link the issue this PR addresses, if any. Use "Closes #123", "Fixes #123", or "Related to #123". -->

## Before opening this PR

- [ ] I have checked that there is not already an open PR for this change.
- [ ] I have checked existing issues and discussions for relevant context.
- [ ] I have read the contributing guidelines.

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Test update
- [ ] Refactor or maintenance
- [ ] Performance improvement
- [ ] Build, CI, or release change

## Affected areas

<!-- Select all that apply. -->

- [ ] Python SDK (`memori/`)
- [ ] TypeScript SDK (`memori-ts/`)
- [ ] Rust core or native bindings (`core/`)
- [ ] LLM providers or adapters
- [ ] Storage adapters or drivers
- [ ] Memory augmentation or recall
- [ ] Examples or integrations
- [ ] Documentation
- [ ] CI, packaging, or tooling

## How was this tested?

<!-- List the commands you ran and any relevant manual checks. If not tested, explain why. -->

- [ ] `uv run pytest`
- [ ] `uv run ruff check .`
- [ ] `uv run ruff format --check .`
- [ ] `npm test` from `memori-ts/`
- [ ] `npm run lint` from `memori-ts/`
- [ ] Integration tests
- [ ] Manual testing

## Checklist

- [ ] I have kept this change focused and consistent with the existing architecture.
- [ ] I have added or updated tests where appropriate.
- [ ] I have updated documentation or examples for user-facing changes.
- [ ] This PR does not require live API keys for unit tests.
- [ ] This PR does not include generated artifacts, local databases, or cache files.
- [ ] I have called out any breaking changes, migration steps, or compatibility concerns below.

## Notes for reviewers

<!-- Add screenshots, API examples, migration notes, risks, or follow-up work that reviewers should know about. -->
