### PR TITLE
Warn users when `allowConversationAccess` is not configured (>= 2026.5.7)

### DIFF
--- a/.github/workflows/publish-openclaw-plugin.yml
+++ b/.github/workflows/publish-openclaw-plugin.yml
@@ -37,4 +37,4 @@ jobs:
         run: npm run build --if-present
 
       - name: Publish Package
-        run: npm publish --access public --tag latest
+        run: npm publish --access public --tag beta

--- a/integrations/openclaw/package-lock.json
+++ b/integrations/openclaw/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memorilabs/openclaw-memori",
-  "version": "0.0.16",
+  "version": "0.0.7-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorilabs/openclaw-memori",
-      "version": "0.0.16",
+      "version": "0.0.7-beta",
       "license": "Apache-2.0",
       "dependencies": {
         "@memorilabs/memori": "^0.1.23-beta"

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorilabs/openclaw-memori",
-  "version": "0.0.16",
+  "version": "0.0.7-beta",
   "description": "Official MemoriLabs.ai long-term memory plugin for OpenClaw",
   "type": "module",
   "main": "./dist/index.js",

--- a/integrations/openclaw/src/index.ts
+++ b/integrations/openclaw/src/index.ts
@@ -37,14 +37,61 @@ const memoriPlugin = {
     logger.info(`\n=== ${PLUGIN_CONFIG.LOG_PREFIX} INITIALIZING PLUGIN ===`);
     logger.info(`${PLUGIN_CONFIG.LOG_PREFIX} Tracking Entity ID: ${config.entityId}`);
 
+    // This code is temp. will be removed when https://github.com/openclaw/openclaw/issues/71428 is fixed.
+    // allowConversationAccess was added to the schema in 2026.4.29.
+    // However, during the 5.2/5.3 package refactor, origin detection was bugged (allowing
+    // bypasses) and the schema validator temporarily rejected the key, crashing the app.
+    // The platform stabilized the plugin loader in 2026.5.7 and re-clarified the rule in 5.9.
+    // Therefore, we only enforce the warning on 2026.5.7 and newer.
+    const ocVersion = api.runtime.version.replace(/^v/, '');
+    const [ocYear = 0, ocMonth = 0, ocDay = 0] = ocVersion
+      .split('.')
+      .map((s) => parseInt(s, 10) || 0);
+
+    const needsAccessPermission =
+      ocYear > 2026 ||
+      (ocYear === 2026 && ocMonth > 5) ||
+      (ocYear === 2026 && ocMonth === 5 && ocDay >= 7);
+
+    const hasConversationAccess =
+      !needsAccessPermission ||
+      api.config.plugins?.entries?.[PLUGIN_CONFIG.ID]?.hooks?.allowConversationAccess === true;
+
+    // B: log at startup so the operator sees it immediately in gateway logs
+    if (!hasConversationAccess) {
+      api.logger.warn(
+        `${PLUGIN_CONFIG.LOG_PREFIX} Conversation access is not enabled — agent_end memory capture will not work.\n` +
+          `  To fix, run:\n` +
+          `    openclaw config set plugins.entries.${PLUGIN_CONFIG.ID}.hooks.allowConversationAccess true\n` +
+          `  Then restart the gateway.`
+      );
+    }
+
     const configContext = `Memori plugin configuration: projectId="${config.projectId}", entityId="${config.entityId}"`;
+
+    const accessWarning = !hasConversationAccess
+      ? [
+          '⚠️ MEMORI SETUP REQUIRED — respond to this before anything else.',
+          'Memory capture is disabled because conversation access is not enabled.',
+          'Tell the user this now:',
+          `  "Memori is installed but not fully set up. Run this command then restart the gateway:"`,
+          `  openclaw config set plugins.entries.${PLUGIN_CONFIG.ID}.hooks.allowConversationAccess true`,
+        ].join('\n')
+      : null;
+
+    // Static skills + config go in appendSystemContext (cached).
+    // The access warning uses prependContext so it lands above the user's message
+    // on every turn — the model reads it before any user input.
     api.on('before_prompt_build', () => ({
       appendSystemContext: [skillsContent, configContext].filter(Boolean).join('\n\n'),
+      ...(accessWarning ? { prependContext: accessWarning } : {}),
     }));
 
-    api.on('agent_end', (event: unknown, ctx: unknown) =>
-      handleAugmentation(event as OpenClawEvent, ctx as OpenClawContext, config, logger)
-    );
+    if (hasConversationAccess) {
+      api.on('agent_end', (event: unknown, ctx: unknown) =>
+        handleAugmentation(event as OpenClawEvent, ctx as OpenClawContext, config, logger)
+      );
+    }
 
     registerAuthenticatedTools({ api, config, logger });
   },

--- a/integrations/openclaw/tests/index.test.ts
+++ b/integrations/openclaw/tests/index.test.ts
@@ -27,6 +27,16 @@ describe('plugin index', () => {
         entityId: 'test-entity-id',
         projectId: 'test-project-id',
       },
+      config: {
+        plugins: {
+          entries: {
+            'openclaw-memori': {
+              hooks: { allowConversationAccess: true },
+            },
+          },
+        },
+      },
+      runtime: { version: '2026.5.15' },
       logger: {
         info: vi.fn(),
         warn: vi.fn(),
@@ -138,6 +148,50 @@ describe('plugin index', () => {
         expect.stringContaining('Missing apiKey or entityId')
       );
       expect(mockOn.mock.calls).toHaveLength(0);
+    });
+  });
+
+  describe('conversation access warning', () => {
+    it('should warn and inject prependContext when allowConversationAccess is not set on OC >= 2026.5.12', () => {
+      mockApi.config = { plugins: { entries: { 'openclaw-memori': {} } } } as any;
+
+      memoriPlugin.register(mockApi);
+
+      expect(mockApi.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Conversation access is not enabled')
+      );
+
+      const handler = mockOn.mock.calls.find((call) => call[0] === 'before_prompt_build')?.[1];
+      const result = handler?.();
+      expect(result).toHaveProperty('prependContext');
+      expect(result.prependContext).toContain('MEMORI SETUP REQUIRED');
+    });
+
+    it('should not warn on OC < 2026.5.12 even if allowConversationAccess is not set', () => {
+      mockApi.runtime = { version: '2026.5.3' } as any;
+      mockApi.config = { plugins: { entries: { 'openclaw-memori': {} } } } as any;
+
+      memoriPlugin.register(mockApi);
+
+      expect(mockApi.logger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('Conversation access is not enabled')
+      );
+
+      const handler = mockOn.mock.calls.find((call) => call[0] === 'before_prompt_build')?.[1];
+      const result = handler?.();
+      expect(result).not.toHaveProperty('prependContext');
+    });
+
+    it('should not warn when allowConversationAccess is true', () => {
+      memoriPlugin.register(mockApi);
+
+      expect(mockApi.logger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('Conversation access is not enabled')
+      );
+
+      const handler = mockOn.mock.calls.find((call) => call[0] === 'before_prompt_build')?.[1];
+      const result = handler?.();
+      expect(result).not.toHaveProperty('prependContext');
     });
   });
 


### PR DESCRIPTION
Since openclaw 2026.4.29, non-bundled plugins must set
`plugins.entries.<id>.hooks.allowConversationAccess: true` to use conversation
hooks like `agent_end`. Without it, the hook is silently blocked and memory
capture never runs.

### Changes

- **Version-gated access check** — only warns on openclaw >= 2026.5.7. The
  config key was introduced in 2026.4.29 but origin detection was bugged during
  the 5.2/5.3 refactor (bypasses allowed, schema validator temporarily rejected
  the key). The loader was stabilized in 2026.5.7.

- **Startup warning (B)** — logs a `warn`-level message at gateway boot so
  operators see the misconfiguration immediately in gateway logs.

- **Per-turn context injection (A)** — injects a `prependContext` block above
  every user message instructing the model to surface the setup requirement
  before doing anything else. Only injected when access is missing; zero token
  cost once configured.

- **Guard `agent_end` registration** — skips registering the `agent_end` hook
  entirely when `hasConversationAccess` is false.

- **Unit tests** — updated mock API with `runtime` and `config`; added a
  `conversation access warning` describe block covering the warning path, the
  version gate, and the happy path.

### How to fix (user-facing)

openclaw config set plugins.entries.openclaw-memori.hooks.allowConversationAccess true
openclaw gateway restart



This is a temporary workaround tracked in
[openclaw#71428](https://github.com/openclaw/openclaw/issues/71428).