### PR TITLE
fix(openclaw): guard runtime version lookup to prevent registration crash on CLI metadata pass

### DIFF
--- a/integrations/openclaw/package-lock.json
+++ b/integrations/openclaw/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memorilabs/openclaw-memori",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorilabs/openclaw-memori",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "license": "Apache-2.0",
       "dependencies": {
         "@memorilabs/memori": "^0.1.23-beta"

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorilabs/openclaw-memori",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Official MemoriLabs.ai long-term memory plugin for OpenClaw",
   "type": "module",
   "main": "./dist/index.js",

--- a/integrations/openclaw/src/index.ts
+++ b/integrations/openclaw/src/index.ts
@@ -43,7 +43,14 @@ const memoriPlugin = {
     // bypasses) and the schema validator temporarily rejected the key, crashing the app.
     // The platform stabilized the plugin loader in 2026.5.7 and re-clarified the rule in 5.9.
     // Therefore, we only enforce the warning on 2026.5.7 and newer.
-    const ocVersion = api.runtime.version.replace(/^v/, '');
+    // `api.runtime` is typed as non-nullable but the loader passes `{}` during
+    // non-`full` registration modes (e.g. cli-metadata). Cast so we can guard.
+    const rawVersion =
+      (api.runtime as { version?: string } | undefined)?.version ??
+      api.version ??
+      process.env.OPENCLAW_VERSION ??
+      '2026.5.18';
+    const ocVersion = rawVersion.replace(/^v/, '');
     const [ocYear = 0, ocMonth = 0, ocDay = 0] = ocVersion
       .split('.')
       .map((s) => parseInt(s, 10) || 0);

--- a/integrations/openclaw/tests/index.test.ts
+++ b/integrations/openclaw/tests/index.test.ts
@@ -193,6 +193,35 @@ describe('plugin index', () => {
       const result = handler?.();
       expect(result).not.toHaveProperty('prependContext');
     });
+
+    it('should not crash when runtime is an empty object (cli-metadata mode)', () => {
+      mockApi.runtime = {} as any;
+      mockApi.config = { plugins: { entries: { 'openclaw-memori': {} } } } as any;
+
+      expect(() => memoriPlugin.register(mockApi)).not.toThrow();
+      expect(mockApi.registerCli).toHaveBeenCalled();
+    });
+
+    it('should not crash when runtime is undefined', () => {
+      mockApi.runtime = undefined as any;
+      mockApi.config = { plugins: { entries: { 'openclaw-memori': {} } } } as any;
+
+      expect(() => memoriPlugin.register(mockApi)).not.toThrow();
+      expect(mockApi.registerCli).toHaveBeenCalled();
+    });
+
+    it('should default conservatively (require allowConversationAccess) when version cannot be resolved', () => {
+      mockApi.runtime = {} as any;
+      (mockApi as any).version = undefined;
+      delete process.env.OPENCLAW_VERSION;
+      mockApi.config = { plugins: { entries: { 'openclaw-memori': {} } } } as any;
+
+      memoriPlugin.register(mockApi);
+
+      expect(mockApi.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Conversation access is not enabled')
+      );
+    });
   });
 
   describe('hook handlers', () => {


### PR DESCRIPTION
## Summary

`@memorilabs/openclaw-memori@0.0.17` crashes during plugin registration when OpenClaw loads the plugin in any non-`full` registration mode (e.g. `cli-metadata`), because `api.runtime` is stubbed as `{}` and `api.runtime.version.replace(...)` throws `TypeError: Cannot read properties of undefined (reading 'replace')`.

OpenClaw's loader catches the throw and rolls back the plugin's registry — including the CLI commands registered earlier in the same `register()` call — so end users see:

[plugins] openclaw-memori failed during register from .../dist/index.js: TypeError: Cannot read properties of undefined (reading 'replace')
[openclaw] Unknown command: openclaw memori



This blocks any `openclaw memori …` command once credentials are configured.

## Root cause

OpenClaw runs `register(api)` multiple times in different `PluginRegistrationMode`s (`full`, `discovery`, `tool-discovery`, `setup-only`, `setup-runtime`, `cli-metadata`). In `cli-metadata` mode, the loader passes `runtime: {}` because the real runtime hasn't booted yet (see `openclaw/dist/loader-*.js`, `registrationMode: "cli-metadata"` branch). The SDK's TypeScript type declares `runtime: PluginRuntime` as non-nullable, which hides this from the compiler — so the version-gate code introduced for the `allowConversationAccess` warning crashes at runtime in the metadata pass.

The crash only surfaced when credentials were configured, because the earlier `if (!config.apiKey || !config.entityId) return;` bail-out short-circuited before reaching the version check on unconfigured installs.

## Fix

`src/index.ts`: guard the runtime version lookup with a fallback chain, casting away the SDK's incorrect non-nullable type:

```ts
const rawVersion =
  (api.runtime as { version?: string } | undefined)?.version ??
  api.version ??
  process.env.OPENCLAW_VERSION ??
  '2026.5.18';
const ocVersion = rawVersion.replace(/^v/, '');
The '2026.5.18' literal is the conservative default — it sits past the 2026.5.7 threshold that gates needsAccessPermission, so when the OC version cannot be resolved we fail closed (require explicit allowConversationAccess opt-in) rather than silently bypassing the consent gate.