### PR TITLE
TS CLI: auto-load .env from cwd to avoid silent env-var misconfig

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -331,6 +331,8 @@ npm run build
 
 Memori provides CLI commands for managing your account and quota:
 
+The CLI uses exported environment variables first, then fills missing values from a `.env` file in the directory where you run the command.
+
 ```bash
 # Check your API quota
 python3 -m memori quota

--- a/README.md
+++ b/README.md
@@ -315,6 +315,8 @@ Once you've obtained an API key, set the following environment variable (used by
 export MEMORI_API_KEY=[api_key]
 ```
 
+The Memori CLI uses your exported environment first, then fills missing values from a `.env` file in the directory where you run the command.
+
 ## Managing Your Quota
 
 At any time, you can check your quota using the Memori CLI (works for both SDKs):

--- a/memori-ts/README.md
+++ b/memori-ts/README.md
@@ -47,7 +47,7 @@ Install the Memori SDK and your preferred LLM client using your package manager 
 npm install @memorilabs/memori
 ```
 
-_(Memori supports `openai`, `@anthropic-ai/sdk`, and `@google/genai` as peer dependencies. Requires Node.js 18 or higher.)_
+_(Memori supports `openai`, `@anthropic-ai/sdk`, and `@google/genai` as peer dependencies. Requires Node.js 20.12.0 or higher.)_
 
 ## Quickstart
 

--- a/memori-ts/README.md
+++ b/memori-ts/README.md
@@ -212,6 +212,8 @@ Once you've obtained an API key, set the following environment variable:
 export MEMORI_API_KEY=[api_key]
 ```
 
+The Memori CLI uses your exported environment first, then fills missing values from a `.env` file in the directory where you run the command.
+
 ## Sign Up and Managing Your Quota
 
 You can sign up and manage your quota using the Memori CLI:

--- a/memori-ts/package-lock.json
+++ b/memori-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memorilabs/memori",
-  "version": "0.1.23-beta",
+  "version": "0.1.24-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorilabs/memori",
-      "version": "0.1.23-beta",
+      "version": "0.1.24-beta",
       "license": "Apache-2.0",
       "dependencies": {
         "@memorilabs/axon": "^0.1.5"
@@ -38,7 +38,7 @@
         "vitest": "^2.1.9"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=20.6.0"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": "*",

--- a/memori-ts/package-lock.json
+++ b/memori-ts/package-lock.json
@@ -38,7 +38,7 @@
         "vitest": "^2.1.9"
       },
       "engines": {
-        "node": ">=20.6.0"
+        "node": ">=20.12.0"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": "*",

--- a/memori-ts/package.json
+++ b/memori-ts/package.json
@@ -126,7 +126,7 @@
     "vitest": "^2.1.9"
   },
   "engines": {
-    "node": ">=20.6.0"
+    "node": ">=20.12.0"
   },
   "dependencies": {
     "@memorilabs/axon": "^0.1.5"

--- a/memori-ts/package.json
+++ b/memori-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorilabs/memori",
-  "version": "0.1.23-beta",
+  "version": "0.1.24-beta",
   "description": "The official TypeScript SDK for Memori",
   "type": "module",
   "main": "./dist/index.js",
@@ -126,7 +126,7 @@
     "vitest": "^2.1.9"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.6.0"
   },
   "dependencies": {
     "@memorilabs/axon": "^0.1.5"

--- a/memori-ts/src/bin/cli.ts
+++ b/memori-ts/src/bin/cli.ts
@@ -1,4 +1,13 @@
 #!/usr/bin/env node
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import process from 'node:process';
+
+const envPath = resolve(process.cwd(), '.env');
+if (existsSync(envPath)) {
+  process.loadEnvFile(envPath);
+}
+
 import { main } from '../cli/router.js';
 
 void main();

--- a/memori-ts/tests/cli/bin/cli.test.ts
+++ b/memori-ts/tests/cli/bin/cli.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const { mainMock } = vi.hoisted(() => ({
+  mainMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../src/cli/router.js', () => ({
+  main: mainMock,
+}));
+
+describe('CLI bin', () => {
+  let originalCwd: string;
+  let originalApiKey: string | undefined;
+  let tempDir: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    originalApiKey = process.env.MEMORI_API_KEY;
+    tempDir = mkdtempSync(join(tmpdir(), 'memori-cli-'));
+    delete process.env.MEMORI_API_KEY;
+    mainMock.mockClear();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    if (originalApiKey === undefined) {
+      delete process.env.MEMORI_API_KEY;
+    } else {
+      process.env.MEMORI_API_KEY = originalApiKey;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('loads MEMORI_API_KEY from .env in the current working directory', async () => {
+    writeFileSync(join(tempDir, '.env'), 'MEMORI_API_KEY=dotenv-key\n');
+    process.chdir(tempDir);
+
+    await import('../../../src/bin/cli.js');
+
+    expect(process.env.MEMORI_API_KEY).toBe('dotenv-key');
+    expect(mainMock).toHaveBeenCalledOnce();
+  });
+
+  it('does not override an exported MEMORI_API_KEY with .env', async () => {
+    writeFileSync(join(tempDir, '.env'), 'MEMORI_API_KEY=dotenv-key\n');
+    process.env.MEMORI_API_KEY = 'exported-key';
+    process.chdir(tempDir);
+
+    await import('../../../src/bin/cli.js');
+
+    expect(process.env.MEMORI_API_KEY).toBe('exported-key');
+    expect(mainMock).toHaveBeenCalledOnce();
+  });
+});

--- a/memori/__main__.py
+++ b/memori/__main__.py
@@ -8,7 +8,9 @@ r"""
                        memorilabs.ai
 """
 
+import os
 import sys
+from pathlib import Path
 from typing import Any
 
 from memori._cli import Cli
@@ -21,7 +23,36 @@ from memori.storage.cockroachdb._cluster_manager import (
 )
 
 
+def _load_env_file() -> None:
+    env_path = Path.cwd() / ".env"
+    if not env_path.is_file():
+        return
+
+    for line in env_path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        if stripped.startswith("export "):
+            stripped = stripped.removeprefix("export ").lstrip()
+
+        key, separator, value = stripped.partition("=")
+        key = key.strip()
+        if not separator or not key or key in os.environ:
+            continue
+
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            value = value[1:-1]
+        else:
+            value = value.split(" #", 1)[0].strip()
+
+        os.environ[key] = value
+
+
 def main():
+    _load_env_file()
+
     cli = Cli(Config())
     cli.banner()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,7 @@
+import os
 import subprocess
 import sys
+from contextlib import nullcontext
 from unittest import mock
 
 import pytest
@@ -26,10 +28,11 @@ def test_cli_banner_contains_key_elements(capsys, mock_config):
 
 
 @pytest.mark.integration
-def test_entrypoint_smoke_run():
+def test_entrypoint_smoke_run(tmp_path):
     result = subprocess.run(
         [sys.executable, "-m", "memori", "--help"],
         capture_output=True,
+        cwd=tmp_path,
         text=True,
         timeout=30,
     )
@@ -38,8 +41,13 @@ def test_entrypoint_smoke_run():
 
 
 class TestCliEntrypoint:
-    def run_main_with_args(self, args):
-        with mock.patch.object(sys, "argv", ["memori"] + args):
+    def run_main_with_args(self, args, load_env_file=False):
+        env_loader = (
+            nullcontext()
+            if load_env_file
+            else mock.patch("memori.__main__._load_env_file")
+        )
+        with mock.patch.object(sys, "argv", ["memori"] + args), env_loader:
             try:
                 main()
             except SystemExit as e:
@@ -85,6 +93,36 @@ class TestCliEntrypoint:
         assert "usage" in output
         assert "cockroachdb" in output
         assert "sign-up" in output
+
+    @mock.patch("memori.__main__.ApiQuotaManager")
+    def test_cli_loads_dotenv_from_cwd(self, mock_manager_cls, monkeypatch, tmp_path):
+        dotenv = tmp_path / ".env"
+        dotenv.write_text("MEMORI_API_KEY=dotenv-key\n", encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("MEMORI_API_KEY", raising=False)
+
+        mock_manager_cls.return_value.execute.return_value = None
+
+        self.run_main_with_args(["quota"], load_env_file=True)
+
+        assert os.environ["MEMORI_API_KEY"] == "dotenv-key"
+        mock_manager_cls.assert_called_once()
+
+    @mock.patch("memori.__main__.ApiQuotaManager")
+    def test_cli_dotenv_does_not_override_exported_env(
+        self, mock_manager_cls, monkeypatch, tmp_path
+    ):
+        dotenv = tmp_path / ".env"
+        dotenv.write_text("MEMORI_API_KEY=dotenv-key\n", encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("MEMORI_API_KEY", "exported-key")
+
+        mock_manager_cls.return_value.execute.return_value = None
+
+        self.run_main_with_args(["quota"], load_env_file=True)
+
+        assert os.environ["MEMORI_API_KEY"] == "exported-key"
+        mock_manager_cls.assert_called_once()
 
     def test_branding_displayed(self, capsys):
         self.run_main_with_args([])


### PR DESCRIPTION
## Summary
- The CLI didn't load `.env` files, so users had to either `export` env vars manually or invoke `node --env-file=.env …` every time. This caused real confusion: a `.env` containing `MEMORI_TEST_MODE=1` plus a staging API key was sitting unused, the CLI hit prod with the wrong Bearer, and auth silently fell back to the Free-plan IP quota instead of returning real data.
- `src/bin/cli.ts` now calls `process.loadEnvFile(.env)` from `process.cwd()` before the rest of the CLI initializes. Silent no-op if no `.env` exists.
- No new runtime deps — uses Node's built-in `process.loadEnvFile` (added in 20.6).
- Bumped `engines.node` from `>=20.0.0` → `>=20.6.0` to match the new minimum.
- Version bumped to `0.1.24-beta`.

## Why import order matters
`process.loadEnvFile()` is called before `import { main } from '../cli/router.js'` so that any module-load-time consumers of `process.env` see the loaded values. In practice the SDK only reads env at `Config` construction time (inside command handlers, post-`void main()`), so this is belt-and-suspenders — but it keeps the contract intuitive for future code.