### PR TITLE
Update API key wording and add quick reference to SKILL.md

### DIFF
--- a/docs/memori-cloud/claude-code/quickstart.mdx
+++ b/docs/memori-cloud/claude-code/quickstart.mdx
@@ -11,7 +11,7 @@ Add structured, persistent memory to Claude Code in three steps.
 
 - [Bun](https://bun.sh) — `curl -fsSL https://bun.sh/install | bash`
 - [Claude Code](https://claude.ai/code)
-- A Memori API Key which is available via the memori signup command/tool.
+- Memori API key — acquire with `memori signup`
 
 ## 1. Install the Skill
 

--- a/docs/memori-cloud/hermes/quickstart.mdx
+++ b/docs/memori-cloud/hermes/quickstart.mdx
@@ -15,7 +15,7 @@ This means Hermes can remember what happened during prior work — tool usage, w
 
 - Hermes Agent with memory provider plugins
 - Python 3.10+
-- A Memori API key from [app.memorilabs.ai](https://app.memorilabs.ai)
+- Memori API key — acquire with `memori signup`
 - An Entity ID to scope memory to a specific user, workspace, agent, or system
 - Optional: a Project ID to scope memory to a specific project or workspace
 

--- a/docs/memori-cloud/openclaw/quickstart.mdx
+++ b/docs/memori-cloud/openclaw/quickstart.mdx
@@ -10,7 +10,7 @@ Get a structured, long-term memory system running in your OpenClaw gateway in th
 ## Prerequisites
 
 - [OpenClaw](https://openclaw.ai) `v2026.3.2` or later
-- A Memori API key from [app.memorilabs.ai](https://app.memorilabs.ai)
+- Memori API key — acquire with `memori signup`
 - An Entity ID to scope memory to a specific user, agent, or system
 - A Project ID to scope memory to a specific project or workspace
 
@@ -70,13 +70,13 @@ Add the following to `~/.openclaw/openclaw.json`:
 
 <Properties>
   <Property name="apiKey" type="string" required>
-    Your Memori API key, available from [app.memorilabs.ai](https://app.memorilabs.ai).
+    Your Memori API key — acquire with `memori signup`.
   </Property>
   <Property name="entityId" type="string" required>
-    A unique identifier for the entity (user, agent, or tenant) to attribute memories to.
+    A unique identifier for the entity (user, agent, or tenant) to attribute memories to. This scopes memory storage to a specific user, application, or system.
   </Property>
   <Property name="projectId" type="string" required>
-    A project or workspace ID used to scope all extracted facts and summaries.
+    A project or workspace ID used to scope all extracted facts and summaries. This isolates memory within a particular project or workspace boundary.
   </Property>
 </Properties>
 

--- a/integrations/openclaw/skills/clawhub/SKILL.md
+++ b/integrations/openclaw/skills/clawhub/SKILL.md
@@ -101,7 +101,7 @@ Alternatively, configure it directly via JSON:
 
 ### Configuration Options
 
-- **apiKey** (required): Your Memori API key from [memorilabs.ai](https://app.memorilabs.ai/signup)
+- **apiKey** (required): Memori API key — acquire with `memori signup`
 - **entityId** (required): Unique identifier for this user's memories
 - **projectId** (required): Scopes all memories to a specific project or workspace
 

--- a/integrations/openclaw/skills/memori/SKILL.md
+++ b/integrations/openclaw/skills/memori/SKILL.md
@@ -6,6 +6,17 @@ Memori automatically captures and structures memory from conversation and execut
 
 ---
 
+## Quick reference
+
+- `memori_recall`: retrieve precise memories by query, project, session, time range, or an allowed source/signal pair.
+- `memori_recall_summary`: retrieve a state summary for session starts, daily briefs, or broad status checks.
+- `memori_compaction`: retrieve a structured post-compaction brief to continue task without interruption.
+- `memori_feedback`: report irrelevant, missing, stale, or especially useful memory behavior.
+- `memori_signup`: create a Memori account or request an API key when the user explicitly asks.
+- `memori_quota`: check usage, quota, storage, or memory capacity when the user asks or limits appear to be reached.
+
+---
+
 ## Core instruction
 
 At the start of a session, you should check the `SKILL.md` file


### PR DESCRIPTION
- Replaced all app.memorilabs.ai API key references with Memori signup across Openclaw, Hermes, Claude Code Quickstart pages
- Synced Configuration Options descriptions in OpenClaw Quickstart to match live site
- Added Quick reference section to integrations/openclaw/skills/memori/SKILL.md
- Update apiKey description in integrations/openclaw/skills/clawhub/SKILL.md