### PR TITLE
Update version to 0.1.7 and implement trace handling in Memori integr…

### DIFF
--- a/integrations/hermes/plugin.yaml
+++ b/integrations/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: memori
-version: 0.1.0
+version: 0.1.7
 description: Structured long-term memory for Hermes Agent using Memori Cloud.
 pip_dependencies:
   - memori

--- a/integrations/hermes/pyproject.toml
+++ b/integrations/hermes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-memori"
-version = "0.1.6"
+version = "0.1.7"
 description = "Official Memori Labs provider for Hermes Agent, enabling structured long-term memory from agent trace and execution."
 authors = [{name = "Memori Labs Team", email = "noc@memorilabs.ai"}]
 license = "Apache-2.0"

--- a/integrations/hermes/src/memori_hermes/__init__.py
+++ b/integrations/hermes/src/memori_hermes/__init__.py
@@ -89,6 +89,61 @@ def _load_config(hermes_home: str | Path | None = None) -> MemoriConfig | None:
     )
 
 
+def _parse_tool_args(arguments: Any) -> dict[str, Any]:
+    if isinstance(arguments, dict):
+        return arguments
+    if isinstance(arguments, str):
+        try:
+            parsed = json.loads(arguments)
+        except json.JSONDecodeError:
+            return {"_raw": arguments}
+        if isinstance(parsed, dict):
+            return parsed
+        return {"value": parsed}
+    if arguments is None:
+        return {}
+    return {"value": arguments}
+
+
+def _derive_trace_from_messages(
+    messages: list[dict[str, Any]] | None,
+) -> dict[str, list[dict[str, Any]]] | None:
+    """Build Memori's provider-owned tool trace from Hermes messages."""
+    if not messages:
+        return None
+
+    tools: list[dict[str, Any]] = []
+    tools_by_id: dict[str, dict[str, Any]] = {}
+
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+
+        if message.get("role") == "assistant":
+            for tool_call in message.get("tool_calls") or []:
+                if not isinstance(tool_call, dict):
+                    continue
+                function = tool_call.get("function") or {}
+                if not isinstance(function, dict):
+                    function = {}
+                tool_call_id = str(tool_call.get("id") or "")
+                item = {
+                    "name": str(function.get("name") or ""),
+                    "args": _parse_tool_args(function.get("arguments")),
+                    "result": None,
+                }
+                tools.append(item)
+                if tool_call_id:
+                    tools_by_id[tool_call_id] = item
+
+        elif message.get("role") == "tool":
+            tool_call_id = str(message.get("tool_call_id") or "")
+            if tool_call_id and tool_call_id in tools_by_id:
+                tools_by_id[tool_call_id]["result"] = message.get("content")
+
+    return {"tools": tools} if tools else None
+
+
 class MemoriMemoryProvider(MemoryProvider):
     """Hermes MemoryProvider implementation backed by Memori Cloud."""
 
@@ -176,6 +231,7 @@ was not provided."""
         assistant_content: str,
         *,
         session_id: str = "",
+        messages: list[dict[str, Any]] | None = None,
     ) -> None:
         if self._client is None:
             return
@@ -184,9 +240,10 @@ was not provided."""
             self._sync_thread.join(timeout=SYNC_JOIN_TIMEOUT_SECS)
 
         active_session = session_id or self._session_id
+        trace = _derive_trace_from_messages(messages)
         self._sync_thread = threading.Thread(
             target=self._sync_turn_background,
-            args=(user_content, assistant_content, active_session),
+            args=(user_content, assistant_content, active_session, trace),
             daemon=True,
         )
         self._sync_thread.start()
@@ -196,6 +253,7 @@ was not provided."""
         user_content: str,
         assistant_content: str,
         session_id: str,
+        trace: dict[str, Any] | None = None,
     ) -> None:
         if self._client is None:
             return
@@ -206,6 +264,7 @@ was not provided."""
                 assistant_content=assistant_content,
                 session_id=session_id,
                 platform=HERMES_PLATFORM,
+                trace=trace,
             )
         except MemoriApiError as exc:
             logger.warning("Memori sync_turn failed: %s", exc)

--- a/integrations/hermes/src/memori_hermes/__init__.py
+++ b/integrations/hermes/src/memori_hermes/__init__.py
@@ -89,6 +89,14 @@ def _load_config(hermes_home: str | Path | None = None) -> MemoriConfig | None:
     )
 
 
+def _content_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if value is None:
+        return ""
+    return str(value)
+
+
 def _parse_tool_args(arguments: Any) -> dict[str, Any]:
     if isinstance(arguments, dict):
         return arguments
@@ -105,17 +113,58 @@ def _parse_tool_args(arguments: Any) -> dict[str, Any]:
     return {"value": arguments}
 
 
+def _current_turn_messages(
+    messages: list[dict[str, Any]] | None,
+    *,
+    user_content: str,
+    assistant_content: str,
+) -> list[dict[str, Any]]:
+    """Return only the completed turn from Hermes' full conversation history."""
+    if not messages:
+        return []
+
+    final_idx: int | None = None
+    for idx in range(len(messages) - 1, -1, -1):
+        message = messages[idx]
+        if not isinstance(message, dict) or message.get("role") != "assistant":
+            continue
+        if _content_text(message.get("content")) == _content_text(assistant_content):
+            final_idx = idx
+            break
+    if final_idx is None:
+        final_idx = len(messages)
+
+    start_idx = 0
+    for idx in range(final_idx - 1, -1, -1):
+        message = messages[idx]
+        if not isinstance(message, dict) or message.get("role") != "user":
+            continue
+        start_idx = idx
+        if _content_text(message.get("content")) == _content_text(user_content):
+            break
+
+    return messages[start_idx : final_idx + 1]
+
+
 def _derive_trace_from_messages(
     messages: list[dict[str, Any]] | None,
+    *,
+    user_content: str,
+    assistant_content: str,
 ) -> dict[str, list[dict[str, Any]]] | None:
-    """Build Memori's provider-owned tool trace from Hermes messages."""
-    if not messages:
+    """Build Memori's provider-owned tool trace from the current Hermes turn."""
+    current_turn = _current_turn_messages(
+        messages,
+        user_content=user_content,
+        assistant_content=assistant_content,
+    )
+    if not current_turn:
         return None
 
     tools: list[dict[str, Any]] = []
     tools_by_id: dict[str, dict[str, Any]] = {}
 
-    for message in messages:
+    for message in current_turn:
         if not isinstance(message, dict):
             continue
 
@@ -240,7 +289,11 @@ was not provided."""
             self._sync_thread.join(timeout=SYNC_JOIN_TIMEOUT_SECS)
 
         active_session = session_id or self._session_id
-        trace = _derive_trace_from_messages(messages)
+        trace = _derive_trace_from_messages(
+            messages,
+            user_content=user_content,
+            assistant_content=assistant_content,
+        )
         self._sync_thread = threading.Thread(
             target=self._sync_turn_background,
             args=(user_content, assistant_content, active_session, trace),

--- a/integrations/hermes/src/memori_hermes/client.py
+++ b/integrations/hermes/src/memori_hermes/client.py
@@ -53,6 +53,7 @@ class MemoriAgentClient:
         assistant_content: str,
         session_id: str,
         platform: str,
+        trace: dict[str, Any] | None = None,
     ) -> None:
         del platform
         try:
@@ -62,6 +63,7 @@ class MemoriAgentClient:
                 project_id=self.project_id,
                 session_id=session_id,
                 platform=MEMORI_PLATFORM,
+                trace=trace,
             )
         except Exception as exc:  # noqa: BLE001
             raise MemoriApiError(str(exc)) from exc

--- a/integrations/hermes/src/memori_hermes/plugin.yaml
+++ b/integrations/hermes/src/memori_hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: memori
-version: 0.1.0
+version: 0.1.7
 description: Structured long-term memory for Hermes Agent using Memori Cloud.
 pip_dependencies:
   - memori

--- a/integrations/hermes/tests/test_client.py
+++ b/integrations/hermes/tests/test_client.py
@@ -92,7 +92,29 @@ def test_capture_turn_writes_default_then_collector(
         "project_id": "project",
         "session_id": "session",
         "platform": "hermes",
+        "trace": None,
     }
+
+
+def test_capture_turn_passes_trace(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = make_client()
+    seen = {}
+    trace = {"tools": [{"name": "terminal", "args": {}, "result": "ok"}]}
+
+    def fake_capture_agent_turn(**kwargs):
+        seen.update(kwargs)
+
+    monkeypatch.setattr(client.memori, "capture_agent_turn", fake_capture_agent_turn)
+
+    client.capture_turn(
+        user_content="u",
+        assistant_content="a",
+        session_id="session",
+        platform="cli",
+        trace=trace,
+    )
+
+    assert seen["trace"] == trace
 
 
 def test_summary_rejects_session_without_project() -> None:

--- a/integrations/hermes/tests/test_provider.py
+++ b/integrations/hermes/tests/test_provider.py
@@ -78,7 +78,7 @@ def test_sync_turn_runs_background_capture() -> None:
     assert client.captured == [("hello", "hi", "session-1", "hermes", None)]
 
 
-def test_sync_turn_derives_trace_from_hermes_messages() -> None:
+def test_sync_turn_derives_trace_from_current_hermes_turn_only() -> None:
     client = FakeClient()
     provider = MemoriMemoryProvider(client=client)
     provider._session_id = "session-1"
@@ -87,6 +87,23 @@ def test_sync_turn_derives_trace_from_hermes_messages() -> None:
         "run tests",
         "tests passed",
         messages=[
+            {"role": "user", "content": "old request"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "old-call",
+                        "type": "function",
+                        "function": {
+                            "name": "terminal",
+                            "arguments": '{"command": "old"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "old-call", "content": "old result"},
+            {"role": "assistant", "content": "old answer"},
+            {"role": "user", "content": "run tests"},
             {
                 "role": "assistant",
                 "tool_calls": [
@@ -100,11 +117,8 @@ def test_sync_turn_derives_trace_from_hermes_messages() -> None:
                     }
                 ],
             },
-            {
-                "role": "tool",
-                "tool_call_id": "call-1",
-                "content": "passed",
-            },
+            {"role": "tool", "tool_call_id": "call-1", "content": "passed"},
+            {"role": "assistant", "content": "tests passed"},
         ],
     )
     provider.shutdown()

--- a/integrations/hermes/tests/test_provider.py
+++ b/integrations/hermes/tests/test_provider.py
@@ -21,8 +21,11 @@ class FakeClient:
         assistant_content: str,
         session_id: str,
         platform: str,
+        trace=None,
     ) -> None:
-        self.captured.append((user_content, assistant_content, session_id, platform))
+        self.captured.append(
+            (user_content, assistant_content, session_id, platform, trace)
+        )
 
     def agent_recall(self, params):
         self.recall_params = params
@@ -72,7 +75,57 @@ def test_sync_turn_runs_background_capture() -> None:
     provider.sync_turn("hello", "hi")
     provider.shutdown()
 
-    assert client.captured == [("hello", "hi", "session-1", "hermes")]
+    assert client.captured == [("hello", "hi", "session-1", "hermes", None)]
+
+
+def test_sync_turn_derives_trace_from_hermes_messages() -> None:
+    client = FakeClient()
+    provider = MemoriMemoryProvider(client=client)
+    provider._session_id = "session-1"
+
+    provider.sync_turn(
+        "run tests",
+        "tests passed",
+        messages=[
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {
+                            "name": "terminal",
+                            "arguments": '{"command": "pytest"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call-1",
+                "content": "passed",
+            },
+        ],
+    )
+    provider.shutdown()
+
+    assert client.captured == [
+        (
+            "run tests",
+            "tests passed",
+            "session-1",
+            "hermes",
+            {
+                "tools": [
+                    {
+                        "name": "terminal",
+                        "args": {"command": "pytest"},
+                        "result": "passed",
+                    }
+                ]
+            },
+        )
+    ]
 
 
 def test_handle_recall_adds_project_default() -> None:


### PR DESCRIPTION
…ation. Added functions to parse tool arguments and derive traces from Hermes messages, enhancing the memory provider's capabilities. Updated tests to validate trace functionality in client and provider interactions.

## What does this PR do?

<!-- Describe the purpose of this change and the problem it solves. -->

## Related issue

<!-- Link the issue this PR addresses, if any. Use "Closes #123", "Fixes #123", or "Related to #123". -->

## Before opening this PR

- [ ] I have checked that there is not already an open PR for this change.
- [ ] I have checked existing issues and discussions for relevant context.
- [ ] I have read the contributing guidelines.

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Test update
- [ ] Refactor or maintenance
- [ ] Performance improvement
- [ ] Build, CI, or release change

## Affected areas

<!-- Select all that apply. -->

- [ ] Python SDK (`memori/`)
- [ ] TypeScript SDK (`memori-ts/`)
- [ ] Rust core or native bindings (`core/`)
- [ ] LLM providers or adapters
- [ ] Storage adapters or drivers
- [ ] Memory augmentation or recall
- [ ] Examples or integrations
- [ ] Documentation
- [ ] CI, packaging, or tooling

## How was this tested?

<!-- List the commands you ran and any relevant manual checks. If not tested, explain why. -->

- [ ] `uv run pytest`
- [ ] `uv run ruff check .`
- [ ] `uv run ruff format --check .`
- [ ] `npm test` from `memori-ts/`
- [ ] `npm run lint` from `memori-ts/`
- [ ] Integration tests
- [ ] Manual testing

## Checklist

- [ ] I have kept this change focused and consistent with the existing architecture.
- [ ] I have added or updated tests where appropriate.
- [ ] I have updated documentation or examples for user-facing changes.
- [ ] This PR does not require live API keys for unit tests.
- [ ] This PR does not include generated artifacts, local databases, or cache files.
- [ ] I have called out any breaking changes, migration steps, or compatibility concerns below.

## Notes for reviewers

<!-- Add screenshots, API examples, migration notes, risks, or follow-up work that reviewers should know about. -->
