### PR TITLE
feat(provisioning): add Neon Launchpad DB provisioning provider

### DIFF
--- a/memori/provisioning/__init__.py
+++ b/memori/provisioning/__init__.py
@@ -9,8 +9,11 @@ from memori.provisioning._models import ProvisionResult
 from memori.provisioning._registry import provision
 from memori.provisioning._utils import (
     mysql_connection_factory,
+    pg_connection_factory,
     redact_dsn,
     require_mysql_driver,
+    require_pg_driver,
+    
 )
 
 # Import providers to trigger registration decorators.
@@ -19,8 +22,9 @@ importlib.import_module("memori.provisioning.providers")
 if TYPE_CHECKING:
     from memori import Memori
 
-SUPPORTED_FAMILIES = {"mysql"}
+SUPPORTED_FAMILIES = {"mysql", "postgres"}
 MYSQL_PROVIDERS = {"tidb-zero"}
+PG_PROVIDERS = {"neon-launchpad"}
 
 
 def get_provision_result(
@@ -59,6 +63,9 @@ def provision_memori(
     if provider in MYSQL_PROVIDERS:
         require_mysql_driver("TiDB Zero")
 
+    elif provider in PG_PROVIDERS:
+        require_pg_driver("Neon Launchpad")
+    
     result = get_provision_result(
         provider=provider,
         cache=cache,
@@ -68,7 +75,13 @@ def provision_memori(
     )
     _validate_family(result)
 
-    mem = Memori(conn=mysql_connection_factory(result.dsn, result.connect_args))
+    if result.family == "mysql":
+        conn_factory = mysql_connection_factory(result.dsn, result.connect_args)
+
+    elif result.family == "postgres":
+        conn_factory = pg_connection_factory(result.dsn, result.connect_args)
+
+    mem = Memori(conn=conn_factory)
     mem.config.provision_result = result
     if build:
         mem.config.storage.build()

--- a/memori/provisioning/__init__.py
+++ b/memori/provisioning/__init__.py
@@ -22,7 +22,7 @@ importlib.import_module("memori.provisioning.providers")
 if TYPE_CHECKING:
     from memori import Memori
 
-SUPPORTED_FAMILIES = {"mysql", "postgres"}
+SUPPORTED_FAMILIES = {"mysql", "postgresql"}
 MYSQL_PROVIDERS = {"tidb-zero"}
 PG_PROVIDERS = {"neon-launchpad"}
 
@@ -78,7 +78,7 @@ def provision_memori(
     if result.family == "mysql":
         conn_factory = mysql_connection_factory(result.dsn, result.connect_args)
 
-    elif result.family == "postgres":
+    elif result.family == "postgresql":
         conn_factory = pg_connection_factory(result.dsn, result.connect_args)
 
     mem = Memori(conn=conn_factory)

--- a/memori/provisioning/_utils.py
+++ b/memori/provisioning/_utils.py
@@ -6,7 +6,7 @@ from urllib.parse import parse_qs, quote, unquote, urlparse, urlunparse
 
 import certifi
 
-from memori._exceptions import MissingPyMySQLError
+from memori._exceptions import MissingPsycopgError, MissingPyMySQLError
 
 DEFAULT_MYSQL_DATABASE = "memori"
 
@@ -123,3 +123,21 @@ def _first(query: dict[str, list[str]], key: str) -> str | None:
     if not values:
         return None
     return values[0]
+
+
+## NEON LAUNCHPAD
+def require_pg_driver(database: str = "Neon Launchpad") -> Any:
+    try:
+        import psycopg
+    except ImportError as e:
+        raise MissingPsycopgError(database) from e
+    return psycopg
+
+
+def pg_connection_factory(
+    dsn: str,
+    connect_args: dict[str, Any] | None = None,
+) -> Callable[[], Any]:
+    psycopg = require_pg_driver("Neon Launchpad")
+    return lambda: psycopg.connect(dsn, **(connect_args or {}))
+

--- a/memori/provisioning/providers/__init__.py
+++ b/memori/provisioning/providers/__init__.py
@@ -1,4 +1,4 @@
 # Import provider modules so their Registry decorators run.
 from memori.provisioning.providers import tidb_zero as tidb_zero
-
-__all__ = ["tidb_zero"]
+from memori.provisioning.providers import neon_launchpad as neon_launchpad
+__all__ = ["tidb_zero", "neon_launchpad"]

--- a/memori/provisioning/providers/neon_launchpad.py
+++ b/memori/provisioning/providers/neon_launchpad.py
@@ -19,6 +19,12 @@ def provision_neon_launchpad(
     url: str | None = None,
     **_kwargs: Any,
 ) -> ProvisionResult:
+    """Provision a PostgreSQL database via the Neon Launchpad API.
+
+    API source: https://neon.tech/docs/reference/claimable-postgres
+    POST to ``/api/v1/database`` with ``{"ref": "<tag>"}``, no auth required.
+    Returns a ``ProvisionResult`` with ``family="postgresql"``.
+    """
     response = requests.post(
         url or os.environ.get("MEMORI_NEON_LAUNCHPAD_URL") or DEFAULT_NEON_LAUNCHPAD_URL,
         json={"ref": tag},
@@ -35,7 +41,7 @@ def parse_neon_launchpad_response(data: dict[str, Any]) -> ProvisionResult:
         
     return ProvisionResult(
         provider="neon-launchpad",
-        family="postgres",
+        family="postgresql",
         dsn=dsn,
         connect_args={},
         claim_url=data["claim_url"] if isinstance(data.get("claim_url"), str) else None,

--- a/memori/provisioning/providers/neon_launchpad.py
+++ b/memori/provisioning/providers/neon_launchpad.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import requests
+
+from memori.provisioning._models import ProvisionResult
+from memori.provisioning._registry import Registry
+
+DEFAULT_NEON_LAUNCHPAD_URL = "https://neon.new/api/v1/database"
+
+
+@Registry.register_provider("neon-launchpad")
+def provision_neon_launchpad(
+    *,
+    tag: str = "memori",
+    timeout: int = 30,
+    url: str | None = None,
+    **_kwargs: Any,
+) -> ProvisionResult:
+    response = requests.post(
+        url or os.environ.get("MEMORI_NEON_LAUNCHPAD_URL") or DEFAULT_NEON_LAUNCHPAD_URL,
+        json={"ref": tag},
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    return parse_neon_launchpad_response(response.json())
+
+
+def parse_neon_launchpad_response(data: dict[str, Any]) -> ProvisionResult:
+    dsn = data.get("connection_string")
+    if not isinstance(dsn, str) or not dsn:
+        raise ValueError("Neon Launchpad response did not include a connection string")
+        
+    return ProvisionResult(
+        provider="neon-launchpad",
+        family="postgres",
+        dsn=dsn,
+        connect_args={},
+        claim_url=data["claim_url"] if isinstance(data.get("claim_url"), str) else None,
+        expires_at=data["expires_at"] if isinstance(data.get("expires_at"), str) else None,
+        metadata={
+            "id": data.get("id"),
+            "status": data.get("status"),
+            "neon_project_id": data.get("neon_project_id"),
+        },
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
 embeddings = []
 sqlalchemy = ["sqlalchemy>=2.0.44"]
 tidb-zero = ["certifi>=2024.0.0", "pymysql>=1.1.2"]
+postgres = ["psycopg[binary]>=3.1.0"]
 cockroachdb = [
     "psycopg[binary]>=3.1.0",
     "sqlalchemy>=2.0.44",

--- a/tests/provisioning/test_neon_launchpad_provider.py
+++ b/tests/provisioning/test_neon_launchpad_provider.py
@@ -1,0 +1,67 @@
+import pytest
+import requests
+
+from memori.provisioning.providers.neon_launchpad import (
+    DEFAULT_NEON_LAUNCHPAD_URL,
+    provision_neon_launchpad,
+)
+
+
+def test_provision_neon_launchpad_posts_to_api(mocker):
+    response = mocker.Mock()
+    response.json.return_value = {
+        "connection_string": "postgresql://user:password@host:port/dbname",
+        "claim_url": "https://neon.new/claim/abc",
+        "expires_at": "2026-06-01T00:00:00Z",
+    }
+
+    post = mocker.patch(
+        "memori.provisioning.providers.neon_launchpad.requests.post",
+        return_value=response,
+    )
+
+    result = provision_neon_launchpad(tag="memori-test", timeout=7)
+
+    post.assert_called_once_with(
+        DEFAULT_NEON_LAUNCHPAD_URL,
+        json={"ref": "memori-test"},
+        timeout=7,
+    )
+    response.raise_for_status.assert_called_once_with()
+    assert result.dsn == "postgresql://user:password@host:port/dbname"
+    assert result.family == "postgres"
+    assert result.claim_url == "https://neon.new/claim/abc"
+
+
+def test_provision_neon_launchpad_supports_url_override_and_bearer_token(mocker):
+    response = mocker.Mock()
+    response.json.return_value = {
+        "connection_string": "postgresql://user:password@host:port/dbname",
+        "claim_url": "https://neon.new/claim/abc",
+        "expires_at": "2026-06-01T00:00:00Z",
+    }
+    post = mocker.patch(
+        "memori.provisioning.providers.neon_launchpad.requests.post",
+        return_value=response,
+    )
+
+    provision_neon_launchpad(url="https://custom.example.com/db")
+
+    post.assert_called_once_with(
+        "https://custom.example.com/db",
+        json={"ref": "memori"},
+        timeout=30,
+    )
+
+
+def test_provision_neon_launchpad_propagates_http_errors(mocker):
+    response = mocker.Mock()
+    response.raise_for_status.side_effect = requests.HTTPError("500")
+    mocker.patch(
+        "memori.provisioning.providers.neon_launchpad.requests.post",
+        return_value=response,
+    )
+    # TEST
+
+    with pytest.raises(requests.HTTPError):
+        provision_neon_launchpad()

--- a/tests/provisioning/test_neon_launchpad_provider.py
+++ b/tests/provisioning/test_neon_launchpad_provider.py
@@ -29,11 +29,11 @@ def test_provision_neon_launchpad_posts_to_api(mocker):
     )
     response.raise_for_status.assert_called_once_with()
     assert result.dsn == "postgresql://user:password@host:port/dbname"
-    assert result.family == "postgres"
+    assert result.family == "postgresql"
     assert result.claim_url == "https://neon.new/claim/abc"
 
 
-def test_provision_neon_launchpad_supports_url_override_and_bearer_token(mocker):
+def test_provision_neon_launchpad_supports_url_override(mocker):
     response = mocker.Mock()
     response.json.return_value = {
         "connection_string": "postgresql://user:password@host:port/dbname",

--- a/tests/provisioning/test_provisioning_flow.py
+++ b/tests/provisioning/test_provisioning_flow.py
@@ -108,6 +108,33 @@ def test_provision_memori_checks_driver_before_provider_or_cache(mocker):
 
 ## PG DRIVE FLOW TEST
 
+def test_provision_memori_postgresql_success_flow(mocker):
+    require_pg = mocker.patch("memori.provisioning.require_pg_driver")
+    result = ProvisionResult(
+        provider="neon-launchpad",
+        family="postgresql",
+        dsn="postgresql://user:pass@host/db",
+    )
+    mocker.patch(
+        "memori.provisioning.get_provision_result",
+        return_value=result,
+    )
+    conn_factory = mocker.Mock()
+    mocker.patch(
+        "memori.provisioning.pg_connection_factory",
+        return_value=conn_factory,
+    )
+    mem = mocker.Mock()
+    mocker.patch("memori.Memori", return_value=mem)
+    build = mocker.patch("memori.storage._manager.Manager.build")
+
+    returned = provision_memori(provider="neon-launchpad", build=True)
+
+    require_pg.assert_called_once_with("Neon Launchpad")
+    build.assert_called_once_with()
+    assert returned is mem
+
+
 def test_provision_memori_checks_pg_driver_before_provider_or_cache(mocker):
     require_driver = mocker.patch(
         "memori.provisioning.require_pg_driver",

--- a/tests/provisioning/test_provisioning_flow.py
+++ b/tests/provisioning/test_provisioning_flow.py
@@ -3,6 +3,7 @@ import pytest
 import memori.provisioning as provisioning
 from memori._exceptions import (
     MissingPyMySQLError,
+    MissingPsycopgError,
     UnsupportedProvisionedDatabaseFamilyError,
 )
 from memori.provisioning import ProvisionResult, get_provision_result, provision_memori
@@ -65,7 +66,7 @@ def test_get_provision_result_rejects_unsupported_family_before_caching(
     def provider(name, **_kwargs):
         return ProvisionResult(
             provider=name,
-            family="postgres",
+            family="unsupported-family",
             dsn="postgresql://user:pass@host/db",
         )
 
@@ -82,7 +83,7 @@ def test_provision_memori_rejects_unsupported_family(mocker):
         "memori.provisioning.get_provision_result",
         return_value=ProvisionResult(
             provider="neon-launchpad",
-            family="postgres",
+            family="unsupported-family",
             dsn="postgresql://user:pass@host/db",
         ),
     )
@@ -102,4 +103,20 @@ def test_provision_memori_checks_driver_before_provider_or_cache(mocker):
         provision_memori(provider="tidb-zero")
 
     require_driver.assert_called_once_with("TiDB Zero")
+    get_result.assert_not_called()
+
+
+## PG DRIVE FLOW TEST
+
+def test_provision_memori_checks_pg_driver_before_provider_or_cache(mocker):
+    require_driver = mocker.patch(
+        "memori.provisioning.require_pg_driver",
+        side_effect=MissingPsycopgError("Neon Launchpad"),
+    )
+    get_result = mocker.patch("memori.provisioning.get_provision_result")
+
+    with pytest.raises(MissingPsycopgError):
+        provision_memori(provider="neon-launchpad")
+
+    require_driver.assert_called_once_with("Neon Launchpad")
     get_result.assert_not_called()


### PR DESCRIPTION
## Related issue
Closes #566

## Affected areas
- [x] Python SDK (`memori/`)

## How was this tested?
- [ ] `uv run pytest` (blocked by Rust build locally)
- [x] Manual code review

And add a note for reviewers:
## Notes for reviewers

**Could not** run tests locally due to the Rust native extension build
requirement. The implementation follows the existing tidb-zero pattern
closely. Flag this for CI review.