### PR TITLE
fix: reject empty strings in attribution() method

### DIFF
--- a/memori/__init__.py
+++ b/memori/__init__.py
@@ -194,11 +194,17 @@ class Memori:
         if not isinstance(entity_id, str):
             raise TypeError("entity_id must be a string")
 
+        if not entity_id:
+            raise ValueError("entity_id cannot be empty")
+
         if len(entity_id) > 100:
             raise RuntimeError("entity_id cannot be greater than 100 characters")
 
         if process_id is not None and not isinstance(process_id, str):
             raise TypeError("process_id must be a string or None")
+
+        if process_id is not None and not process_id:
+            raise ValueError("process_id cannot be empty")
 
         if process_id is not None and len(process_id) > 100:
             raise RuntimeError("process_id cannot be greater than 100 characters")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -138,6 +138,34 @@ def test_attribution_requires_string_or_none_process_id(mocker):
     assert mem.config.process_id is None
 
 
+def test_attribution_rejects_empty_entity_id(mocker):
+    mock_conn = mocker.Mock(spec=["cursor", "commit", "rollback"])
+    mock_conn.__module__ = "psycopg"
+    type(mock_conn).__module__ = "psycopg"
+    mock_cursor = mocker.MagicMock()
+    mock_conn.cursor = mocker.MagicMock(return_value=mock_cursor)
+
+    with pytest.raises(ValueError) as e:
+        Memori(conn=lambda: mock_conn).attribution(entity_id="")
+
+    assert str(e.value) == "entity_id cannot be empty"
+
+
+def test_attribution_rejects_empty_process_id(mocker):
+    mock_conn = mocker.Mock(spec=["cursor", "commit", "rollback"])
+    mock_conn.__module__ = "psycopg"
+    type(mock_conn).__module__ = "psycopg"
+    mock_cursor = mocker.MagicMock()
+    mock_conn.cursor = mocker.MagicMock(return_value=mock_cursor)
+
+    with pytest.raises(ValueError) as e:
+        Memori(conn=lambda: mock_conn).attribution(
+            entity_id="user-1", process_id=""
+        )
+
+    assert str(e.value) == "process_id cannot be empty"
+
+
 def test_new_session(mocker):
     mock_conn = mocker.Mock(spec=["cursor", "commit", "rollback"])
     mock_conn.__module__ = "psycopg"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -159,9 +159,7 @@ def test_attribution_rejects_empty_process_id(mocker):
     mock_conn.cursor = mocker.MagicMock(return_value=mock_cursor)
 
     with pytest.raises(ValueError) as e:
-        Memori(conn=lambda: mock_conn).attribution(
-            entity_id="user-1", process_id=""
-        )
+        Memori(conn=lambda: mock_conn).attribution(entity_id="user-1", process_id="")
 
     assert str(e.value) == "process_id cannot be empty"
 


### PR DESCRIPTION
## What is the bug?

The attribution() method accepted empty entity_id and process_id strings without validation. Empty strings silently bypass existing length checks and get stored in the database, potentially causing data integrity issues.

## Where does it live?

- File: memori/__init__.py, attribution() method
- Core Memori initialization and memory attribution tracking

## What does the fix do?

Added validation to reject empty strings by checking if not entity_id and if not process_id, raising ValueError with clear messages.

## How to verify

Run tests: uv run pytest tests/test_init.py::test_attribution_rejects_empty_entity_id tests/test_init.py::test_attribution_rejects_empty_process_id

## Path to merge

Merge to main. No database migrations or breaking changes.

## Blocker and expected action

Prevents silent data corruption from empty attribution identifiers. Merge to improve validation robustness in attribution tracking.