### PR TITLE
fix: validate recall() limit parameter

### DIFF
--- a/memori/__init__.py
+++ b/memori/__init__.py
@@ -223,6 +223,12 @@ class Memori:
         self, query: str, limit: int | None = None
     ) -> list[RecallFact] | CloudRecallResponse:
         """Return relevant memories for a query."""
+        if limit is not None:
+            if not isinstance(limit, int):
+                raise TypeError("limit must be an integer or None")
+            if limit <= 0:
+                raise ValueError("limit must be greater than 0")
+
         if self.config.cloud is False and self.config.rust_core is not None:
             resolved_limit = self.config.recall_facts_limit if limit is None else limit
             if not self.config.entity_id:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -186,6 +186,37 @@ def test_set_session_resets_cache(mocker):
     assert mem.config.cache.session_id is None
 
 
+def test_recall_rejects_non_integer_limit(mocker):
+    mock_conn = mocker.Mock(spec=["cursor", "commit", "rollback"])
+    mock_conn.__module__ = "psycopg"
+    type(mock_conn).__module__ = "psycopg"
+    mock_cursor = mocker.MagicMock()
+    mock_conn.cursor = mocker.MagicMock(return_value=mock_cursor)
+
+    with pytest.raises(TypeError) as e:
+        Memori(conn=lambda: mock_conn).recall("test", limit="5")
+
+    assert str(e.value) == "limit must be an integer or None"
+
+
+def test_recall_rejects_zero_or_negative_limit(mocker):
+    mock_conn = mocker.Mock(spec=["cursor", "commit", "rollback"])
+    mock_conn.__module__ = "psycopg"
+    type(mock_conn).__module__ = "psycopg"
+    mock_cursor = mocker.MagicMock()
+    mock_conn.cursor = mocker.MagicMock(return_value=mock_cursor)
+
+    with pytest.raises(ValueError) as e:
+        Memori(conn=lambda: mock_conn).recall("test", limit=0)
+
+    assert str(e.value) == "limit must be greater than 0"
+
+    with pytest.raises(ValueError) as e:
+        Memori(conn=lambda: mock_conn).recall("test", limit=-5)
+
+    assert str(e.value) == "limit must be greater than 0"
+
+
 def test_embed_texts_uses_config_defaults(mocker):
     mock_conn = mocker.Mock(spec=["cursor", "commit", "rollback"])
     mock_conn.__module__ = "psycopg"


### PR DESCRIPTION
## What is the bug?

The recall() method accepted invalid limit values (zero, negative, non-integer) without validation. These invalid values could cause errors downstream in the Rust core or database layer.

## Where does it live?

- File: memori/__init__.py, recall() method
- Core memory search and retrieval functionality

## What does the fix do?

Added parameter validation to reject:
- Non-integer limit values with TypeError
- Limit values less than or equal to zero with ValueError

## How to verify

Run tests: uv run pytest tests/test_init.py::test_recall_rejects_non_integer_limit tests/test_init.py::test_recall_rejects_zero_or_negative_limit

## Path to merge

Merge to main. No breaking changes for valid usage.

## Blocker and expected action

Prevents undefined behavior from invalid recall parameters. Merge to improve input validation robustness.