### PR TITLE
fix: validate API quota response structure

### DIFF
--- a/memori/api/_quota.py
+++ b/memori/api/_quota.py
@@ -22,6 +22,22 @@ class Manager:
 
         response = Api(self.config).get("sdk/quota")
 
-        cli.notice("Maximum # of Memories: " + f"{response['memories']['max']:,}")
-        cli.notice("Current # of Memories: " + f"{response['memories']['num']:,}\n")
-        cli.notice(f"{response['message']}\n")
+        if not isinstance(response, dict):
+            raise ValueError("Unexpected quota response format")
+
+        memories = response.get("memories")
+        if not isinstance(memories, dict):
+            raise ValueError("Missing or invalid 'memories' field in quota response")
+
+        max_memories = memories.get("max")
+        current_memories = memories.get("num")
+        if max_memories is None or current_memories is None:
+            raise ValueError("Missing 'max' or 'num' field in quota response")
+
+        message = response.get("message")
+        if not isinstance(message, str):
+            raise ValueError("Missing or invalid 'message' field in quota response")
+
+        cli.notice("Maximum # of Memories: " + f"{max_memories:,}")
+        cli.notice("Current # of Memories: " + f"{current_memories:,}\n")
+        cli.notice(f"{message}\n")


### PR DESCRIPTION
## What is the bug?

The quota manager directly accessed nested dictionary keys without validation. If the API returned an unexpected response structure, KeyError crashes would occur instead of meaningful error messages.

## Where does it live?

- File: memori/api/_quota.py, execute() method
- SDK quota information retrieval

## What does the fix do?

Added defensive validation to:
- Check response is a dict
- Validate presence of 'memories' dict
- Validate 'max' and 'num' fields exist
- Validate 'message' field is a string

## How to verify

The fix prevents crashes by validating response structure before accessing keys.

## Path to merge

Merge to main. No user-facing changes for valid API responses.

## Blocker and expected action

Prevents crashes from malformed API responses. Merge to improve error resilience.