### PR TITLE
fix: add validation for embedding format

### DIFF
--- a/memori/embeddings/_format.py
+++ b/memori/embeddings/_format.py
@@ -16,7 +16,16 @@ from typing import Any
 
 
 def format_embedding_for_db(embedding: list[float], dialect: str) -> Any:
-    binary_data = struct.pack(f"<{len(embedding)}f", *embedding)
+    if not isinstance(embedding, list):
+        raise TypeError(f"embedding must be a list, got {type(embedding).__name__}")
+
+    if not embedding:
+        raise ValueError("embedding cannot be empty")
+
+    try:
+        binary_data = struct.pack(f"<{len(embedding)}f", *embedding)
+    except (struct.error, TypeError) as e:
+        raise ValueError(f"embedding values must be numeric floats: {e}") from e
 
     if dialect == "mongodb":
         try:


### PR DESCRIPTION
## What is the bug?

The embedding formatter didn't validate input before processing. Invalid embeddings (not a list, empty, or non-numeric values) would cause unclear struct.pack errors rather than meaningful validation errors.

## Where does it live?

- File: memori/embeddings/_format.py, format_embedding_for_db() function
- Vector embedding processing for database storage

## What does the fix do?

Added validation to:
- Check embedding is a list
- Check embedding is not empty
- Catch struct.pack errors and wrap with clear ValueError message

## How to verify

Invalid inputs now raise clear ValueError instead of struct.pack errors.

## Path to merge

Merge to main. No user-facing changes for valid embeddings.

## Blocker and expected action

Prevents silent failures and confusing errors in embedding processing. Merge to improve data validation robustness.