### PR TITLE
Relax vitest devDependency versions

### DIFF
--- a/integrations/openclaw/package-lock.json
+++ b/integrations/openclaw/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@eslint/js": "^9.0.0",
         "@types/node": "^20.0.0",
-        "@vitest/coverage-v8": "^4.0.18",
+        "@vitest/coverage-v8": ">=4.1.0",
         "eslint": "^9.0.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-tsdoc": "^0.5.1",
@@ -22,7 +22,7 @@
         "prettier": "^3.0.0",
         "typescript": "^5.0.0",
         "typescript-eslint": "^8.0.0",
-        "vitest": "^4.0.18"
+        "vitest": ">=4.1.0"
       },
       "engines": {
         "node": ">=22.0.0"

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@eslint/js": "^9.0.0",
     "@types/node": "^20.0.0",
-    "@vitest/coverage-v8": "^4.0.18",
+    "@vitest/coverage-v8": ">=4.1.0",
     "eslint": "^9.0.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-tsdoc": "^0.5.1",
@@ -41,7 +41,7 @@
     "prettier": "^3.0.0",
     "typescript": "^5.0.0",
     "typescript-eslint": "^8.0.0",
-    "vitest": "^4.0.18"
+    "vitest": ">=4.1.0"
   },
   "keywords": [
     "openclaw",


### PR DESCRIPTION
Loosen version constraints for vitest and @vitest/coverage-v8 in integrations/openclaw/package.json from ^4.0.18 to >=4.1.0 so the project can use newer 4.1.x+ releases and take advantage of fixes/features in those updates.

## What does this PR do?

<!-- Describe the purpose of this change and the problem it solves. -->

## Related issue

<!-- Link the issue this PR addresses, if any. Use "Closes #123", "Fixes #123", or "Related to #123". -->

## Before opening this PR

- [ ] I have checked that there is not already an open PR for this change.
- [ ] I have checked existing issues and discussions for relevant context.
- [ ] I have read the contributing guidelines.

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Test update
- [ ] Refactor or maintenance
- [ ] Performance improvement
- [ ] Build, CI, or release change

## Affected areas

<!-- Select all that apply. -->

- [ ] Python SDK (`memori/`)
- [ ] TypeScript SDK (`memori-ts/`)
- [ ] Rust core or native bindings (`core/`)
- [ ] LLM providers or adapters
- [ ] Storage adapters or drivers
- [ ] Memory augmentation or recall
- [ ] Examples or integrations
- [ ] Documentation
- [ ] CI, packaging, or tooling

## How was this tested?

<!-- List the commands you ran and any relevant manual checks. If not tested, explain why. -->

- [ ] `uv run pytest`
- [ ] `uv run ruff check .`
- [ ] `uv run ruff format --check .`
- [ ] `npm test` from `memori-ts/`
- [ ] `npm run lint` from `memori-ts/`
- [ ] Integration tests
- [ ] Manual testing

## Checklist

- [ ] I have kept this change focused and consistent with the existing architecture.
- [ ] I have added or updated tests where appropriate.
- [ ] I have updated documentation or examples for user-facing changes.
- [ ] This PR does not require live API keys for unit tests.
- [ ] This PR does not include generated artifacts, local databases, or cache files.
- [ ] I have called out any breaking changes, migration steps, or compatibility concerns below.

## Notes for reviewers

<!-- Add screenshots, API examples, migration notes, risks, or follow-up work that reviewers should know about. -->
