### PR TITLE
Add enterprise VPC support via MEMORI_DOMAIN and MEMORI_ENV

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -66,7 +66,7 @@ jobs:
           - 27017:27017
 
     env:
-      MEMORI_TEST_MODE: "1"
+      MEMORI_ENV: "staging"
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
@@ -177,7 +177,7 @@ jobs:
           echo "=========================================="
           echo "Integration Test Summary"
           echo "=========================================="
-          echo "MEMORI_TEST_MODE: $MEMORI_TEST_MODE (staging)"
+          echo "MEMORI_ENV: $MEMORI_ENV"
           echo ""
           echo "Tests run:"
           echo "  - AA Payload Unit Tests: Yes (no API keys needed)"

--- a/Makefile
+++ b/Makefile
@@ -57,12 +57,12 @@ run-unit: ## Run unit tests (no API keys needed)
 	uv run pytest tests/ --ignore=tests/integration --ignore=tests/benchmarks -v --tb=short
 
 run-integration: ## Run all integration tests (requires API keys)
-	@echo "Running all integration tests with MEMORI_TEST_MODE=1..."
-	MEMORI_TEST_MODE=1 uv run pytest tests/integration/ -v -m integration --tb=short
+	@echo "Running all integration tests with MEMORI_ENV=staging..."
+	MEMORI_ENV=staging uv run pytest tests/integration/ -v -m integration --tb=short
 
 run-integration-provider: ## Run specific provider tests (e.g., make run-integration-provider P=openai)
 	@echo "Running $(P) integration tests..."
-	MEMORI_TEST_MODE=1 uv run pytest tests/integration/providers/test_$(P).py -v -m integration --tb=short
+	MEMORI_ENV=staging uv run pytest tests/integration/providers/test_$(P).py -v -m integration --tb=short
 
 run-integration-cloud: ## Run cloud integration tests (production API, requires MEMORI_API_KEY)
 	@echo "Running cloud integration tests..."

--- a/core/README.md
+++ b/core/README.md
@@ -86,7 +86,8 @@ Runtime knobs read from the environment (all optional):
 | `MEMORI_API_URL_BASE`           | Override the Memori API base URL                            | `https://api.memorilabs.ai`          |
 | `MEMORI_X_API_KEY`              | Override the `X-Memori-API-Key` header                      | built-in public key                  |
 | `MEMORI_API_KEY`                | Optional bearer token for per-tenant quota                  | unset                                |
-| `MEMORI_TEST_MODE`              | When `1`, point at `staging-*.memorilabs.ai`                | `0`                                  |
+| `MEMORI_ENV`                    | When `staging`, point at `staging-*.memorilabs.ai`          | unset (production)                   |
+| `MEMORI_DOMAIN`                 | Tenant domain for private VPC (e.g. `acme.memorilabs.ai`)  | unset (public endpoints)             |
 | `MEMORI_RECALL_LEX_WEIGHT`      | Lexical weight for hybrid re-rank (clamped `[0.05, 0.40]`)  | `0.15`                               |
 | `MEMORI_RECALL_LEX_WEIGHT_SHORT`| Lexical weight for short queries (≤ 2 tokens)               | `0.30`                               |
 

--- a/core/bindings/node/src/engine.rs
+++ b/core/bindings/node/src/engine.rs
@@ -1,6 +1,9 @@
 use crate::bridge::NodeConnectionFactory;
 use crate::types::*;
 use engine_orchestrator::EngineOrchestrator;
+use engine_orchestrator::network::{
+    ApiSubdomain, resolve_base_url, resolve_x_api_key as core_resolve_x_api_key,
+};
 use engine_orchestrator::search::FactId;
 use engine_orchestrator::storage::models::RankedFact;
 use engine_orchestrator::storage::{Dialect, RustStorageManager, StorageBridge, WriteBatch};
@@ -255,4 +258,18 @@ fn fact_id_from_json(v: &serde_json::Value) -> Option<Either<i64, String>> {
         serde_json::Value::String(s) => Some(Either::B(s.clone())),
         _ => None,
     }
+}
+
+#[napi]
+pub fn resolve_api_base_url(subdomain: String) -> String {
+    let sub = match subdomain.as_str() {
+        "collector" => ApiSubdomain::Collector,
+        _ => ApiSubdomain::Default,
+    };
+    resolve_base_url(&sub)
+}
+
+#[napi]
+pub fn resolve_x_api_key() -> String {
+    core_resolve_x_api_key()
 }

--- a/core/bindings/node/src/engine.rs
+++ b/core/bindings/node/src/engine.rs
@@ -1,9 +1,6 @@
 use crate::bridge::NodeConnectionFactory;
 use crate::types::*;
 use engine_orchestrator::EngineOrchestrator;
-use engine_orchestrator::network::{
-    ApiSubdomain, resolve_base_url, resolve_x_api_key as core_resolve_x_api_key,
-};
 use engine_orchestrator::search::FactId;
 use engine_orchestrator::storage::models::RankedFact;
 use engine_orchestrator::storage::{Dialect, RustStorageManager, StorageBridge, WriteBatch};
@@ -258,18 +255,4 @@ fn fact_id_from_json(v: &serde_json::Value) -> Option<Either<i64, String>> {
         serde_json::Value::String(s) => Some(Either::B(s.clone())),
         _ => None,
     }
-}
-
-#[napi]
-pub fn resolve_api_base_url(subdomain: String) -> String {
-    let sub = match subdomain.as_str() {
-        "collector" => ApiSubdomain::Collector,
-        _ => ApiSubdomain::Default,
-    };
-    resolve_base_url(&sub)
-}
-
-#[napi]
-pub fn resolve_x_api_key() -> String {
-    core_resolve_x_api_key()
 }

--- a/core/bindings/python/src/lib.rs
+++ b/core/bindings/python/src/lib.rs
@@ -13,7 +13,6 @@ use std::sync::mpsc;
 use std::time::Duration;
 
 use engine_orchestrator::augmentation::AugmentationInput;
-use engine_orchestrator::network::{ApiSubdomain, resolve_base_url, resolve_x_api_key};
 use engine_orchestrator::retrieval::RetrievalRequest;
 use engine_orchestrator::search::FactId;
 use engine_orchestrator::storage::{
@@ -271,21 +270,6 @@ fn core_postprocess_request(payload: &str) -> PyResult<u64> {
 }
 
 #[pyfunction]
-fn resolve_api_base_url(subdomain: &str) -> String {
-    let sub = match subdomain {
-        "collector" => ApiSubdomain::Collector,
-        _ => ApiSubdomain::Default,
-    };
-    resolve_base_url(&sub)
-}
-
-#[pyfunction]
-#[pyo3(name = "resolve_x_api_key")]
-fn resolve_x_api_key_py() -> String {
-    resolve_x_api_key()
-}
-
-#[pyfunction]
 #[pyo3(signature = (texts, model_name=None))]
 fn embed_texts(
     py: Python<'_>,
@@ -351,7 +335,5 @@ fn memori_python(_py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResult<()> 
     module.add_function(wrap_pyfunction!(hello_world, module)?)?;
     module.add_function(wrap_pyfunction!(core_postprocess_request, module)?)?;
     module.add_function(wrap_pyfunction!(embed_texts, module)?)?;
-    module.add_function(wrap_pyfunction!(resolve_api_base_url, module)?)?;
-    module.add_function(wrap_pyfunction!(resolve_x_api_key_py, module)?)?;
     Ok(())
 }

--- a/core/bindings/python/src/lib.rs
+++ b/core/bindings/python/src/lib.rs
@@ -13,6 +13,7 @@ use std::sync::mpsc;
 use std::time::Duration;
 
 use engine_orchestrator::augmentation::AugmentationInput;
+use engine_orchestrator::network::{ApiSubdomain, resolve_base_url, resolve_x_api_key};
 use engine_orchestrator::retrieval::RetrievalRequest;
 use engine_orchestrator::search::FactId;
 use engine_orchestrator::storage::{
@@ -270,6 +271,21 @@ fn core_postprocess_request(payload: &str) -> PyResult<u64> {
 }
 
 #[pyfunction]
+fn resolve_api_base_url(subdomain: &str) -> String {
+    let sub = match subdomain {
+        "collector" => ApiSubdomain::Collector,
+        _ => ApiSubdomain::Default,
+    };
+    resolve_base_url(&sub)
+}
+
+#[pyfunction]
+#[pyo3(name = "resolve_x_api_key")]
+fn resolve_x_api_key_py() -> String {
+    resolve_x_api_key()
+}
+
+#[pyfunction]
 #[pyo3(signature = (texts, model_name=None))]
 fn embed_texts(
     py: Python<'_>,
@@ -335,5 +351,7 @@ fn memori_python(_py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResult<()> 
     module.add_function(wrap_pyfunction!(hello_world, module)?)?;
     module.add_function(wrap_pyfunction!(core_postprocess_request, module)?)?;
     module.add_function(wrap_pyfunction!(embed_texts, module)?)?;
+    module.add_function(wrap_pyfunction!(resolve_api_base_url, module)?)?;
+    module.add_function(wrap_pyfunction!(resolve_x_api_key_py, module)?)?;
     Ok(())
 }

--- a/core/src/network/client.rs
+++ b/core/src/network/client.rs
@@ -37,7 +37,9 @@ impl MemoriClient {
     /// Initializes the client from environment variables.
     pub fn new(subdomain: ApiSubdomain) -> Result<Self, ApiError> {
         let prefix = subdomain.as_str();
-        let is_staging = env::var("MEMORI_ENV").unwrap_or_default() == "staging";
+        let env_prefix = env::var("MEMORI_ENV").unwrap_or_default();
+        let env_prefix = env_prefix.trim();
+        let is_production = env_prefix.is_empty();
 
         let (base_url, x_api_key) = {
             let x_key = env::var("MEMORI_X_API_KEY");
@@ -45,25 +47,25 @@ impl MemoriClient {
             if let Ok(domain) = env::var("MEMORI_DOMAIN") {
                 let domain = domain.trim().to_string();
                 if !domain.is_empty() {
-                    let url = if is_staging {
-                        format!("https://staging-{}.{}", prefix, domain)
-                    } else {
+                    let url = if is_production {
                         format!("https://{}.{}", prefix, domain)
+                    } else {
+                        format!("https://{}-{}.{}", env_prefix, prefix, domain)
                     };
                     let key = x_key.unwrap_or_else(|_| {
-                        if is_staging {
-                            PUBLIC_STAGING_KEY
-                        } else {
+                        if is_production {
                             PUBLIC_PROD_KEY
+                        } else {
+                            PUBLIC_STAGING_KEY
                         }
                         .to_string()
                     });
                     (url, key)
                 } else {
-                    Self::resolve_fallback(prefix, is_staging, x_key)
+                    Self::resolve_fallback(prefix, env_prefix, is_production, x_key)
                 }
             } else {
-                Self::resolve_fallback(prefix, is_staging, x_key)
+                Self::resolve_fallback(prefix, env_prefix, is_production, x_key)
             }
         };
 
@@ -84,7 +86,8 @@ impl MemoriClient {
 
     fn resolve_fallback(
         prefix: &str,
-        is_staging: bool,
+        env_prefix: &str,
+        is_production: bool,
         x_key: Result<String, env::VarError>,
     ) -> (String, String) {
         if let Ok(url) = env::var("MEMORI_API_URL_BASE") {
@@ -95,17 +98,20 @@ impl MemoriClient {
             }
         }
         let key = x_key.unwrap_or_else(|_| {
-            if is_staging {
-                PUBLIC_STAGING_KEY
-            } else {
+            if is_production {
                 PUBLIC_PROD_KEY
+            } else {
+                PUBLIC_STAGING_KEY
             }
             .to_string()
         });
-        if is_staging {
-            (format!("https://staging-{}.memorilabs.ai", prefix), key)
-        } else {
+        if is_production {
             (format!("https://{}.memorilabs.ai", prefix), key)
+        } else {
+            (
+                format!("https://{}-{}.memorilabs.ai", env_prefix, prefix),
+                key,
+            )
         }
     }
 

--- a/core/src/network/client.rs
+++ b/core/src/network/client.rs
@@ -8,6 +8,9 @@ use tokio::time::sleep;
 
 use crate::network::error::ApiError;
 
+const PUBLIC_PROD_KEY: &str = "96a7ea3e-11c2-428c-b9ae-5a168363dc80";
+const PUBLIC_STAGING_KEY: &str = "c18b1022-7fe2-42af-ab01-b1f9139184f0";
+
 pub enum ApiSubdomain {
     Default,
     Collector,
@@ -22,6 +25,76 @@ impl ApiSubdomain {
     }
 }
 
+/// Resolves the API base URL from environment variables.
+///
+/// Priority:
+/// 1. `MEMORI_ENTERPRISE_PRODUCTION_DOMAIN` → `https://{subdomain}.{domain}`
+/// 2. `MEMORI_ENTERPRISE_STAGING_DOMAIN`    → `https://staging-{subdomain}.{domain}`
+/// 3. `MEMORI_API_URL_BASE`                 → verbatim (backward compat)
+/// 4. `MEMORI_TEST_MODE=1`                  → `https://staging-{subdomain}.memorilabs.ai`
+/// 5. Default                               → `https://{subdomain}.memorilabs.ai`
+pub fn resolve_base_url(subdomain: &ApiSubdomain) -> String {
+    let prefix = subdomain.as_str();
+
+    if let Ok(domain) = env::var("MEMORI_ENTERPRISE_PRODUCTION_DOMAIN") {
+        let domain = domain.trim().to_string();
+        if !domain.is_empty() {
+            return format!("https://{}.{}", prefix, domain);
+        }
+    }
+
+    if let Ok(domain) = env::var("MEMORI_ENTERPRISE_STAGING_DOMAIN") {
+        let domain = domain.trim().to_string();
+        if !domain.is_empty() {
+            return format!("https://staging-{}.{}", prefix, domain);
+        }
+    }
+
+    if let Ok(url) = env::var("MEMORI_API_URL_BASE") {
+        let url = url.trim().to_string();
+        if !url.is_empty() {
+            return url;
+        }
+    }
+
+    let test_mode = env::var("MEMORI_TEST_MODE").unwrap_or_default() == "1";
+    if test_mode {
+        format!("https://staging-{}.memorilabs.ai", prefix)
+    } else {
+        format!("https://{}.memorilabs.ai", prefix)
+    }
+}
+
+/// Resolves the X-Memori-API-Key from environment variables.
+///
+/// Returns the production key for enterprise production and default production,
+/// the staging key for all other cases. Always respects `MEMORI_X_API_KEY` override.
+pub fn resolve_x_api_key() -> String {
+    let override_key = env::var("MEMORI_X_API_KEY");
+
+    let enterprise_prod = env::var("MEMORI_ENTERPRISE_PRODUCTION_DOMAIN")
+        .map(|d| !d.trim().is_empty())
+        .unwrap_or(false);
+
+    if enterprise_prod {
+        return override_key.unwrap_or_else(|_| PUBLIC_PROD_KEY.to_string());
+    }
+
+    let uses_staging = env::var("MEMORI_ENTERPRISE_STAGING_DOMAIN")
+        .map(|d| !d.trim().is_empty())
+        .unwrap_or(false)
+        || env::var("MEMORI_API_URL_BASE")
+            .map(|u| !u.trim().is_empty())
+            .unwrap_or(false)
+        || env::var("MEMORI_TEST_MODE").unwrap_or_default() == "1";
+
+    if uses_staging {
+        override_key.unwrap_or_else(|_| PUBLIC_STAGING_KEY.to_string())
+    } else {
+        override_key.unwrap_or_else(|_| PUBLIC_PROD_KEY.to_string())
+    }
+}
+
 #[derive(Clone)]
 pub struct MemoriClient {
     client: Client,
@@ -33,32 +106,8 @@ pub struct MemoriClient {
 impl MemoriClient {
     /// Initializes the client from environment variables.
     pub fn new(subdomain: ApiSubdomain) -> Result<Self, ApiError> {
-        let test_mode = env::var("MEMORI_TEST_MODE").unwrap_or_else(|_| "0".to_string()) == "1";
-
-        // Match Python SDK defaults for base URL and X-Memori-API-Key.
-        let (base_url, x_api_key) = match env::var("MEMORI_API_URL_BASE") {
-            Ok(url) => (
-                url,
-                env::var("MEMORI_X_API_KEY")
-                    .unwrap_or_else(|_| "c18b1022-7fe2-42af-ab01-b1f9139184f0".to_string()),
-            ),
-            Err(_) => {
-                if test_mode {
-                    (
-                        format!("https://staging-{}.memorilabs.ai", subdomain.as_str()),
-                        env::var("MEMORI_X_API_KEY")
-                            .unwrap_or_else(|_| "c18b1022-7fe2-42af-ab01-b1f9139184f0".to_string()),
-                    )
-                } else {
-                    (
-                        format!("https://{}.memorilabs.ai", subdomain.as_str()),
-                        env::var("MEMORI_X_API_KEY")
-                            .unwrap_or_else(|_| "96a7ea3e-11c2-428c-b9ae-5a168363dc80".to_string()),
-                    )
-                }
-            }
-        };
-
+        let base_url = resolve_base_url(&subdomain);
+        let x_api_key = resolve_x_api_key();
         let api_key = env::var("MEMORI_API_KEY").ok();
 
         let client = Client::builder()

--- a/core/src/network/client.rs
+++ b/core/src/network/client.rs
@@ -25,76 +25,6 @@ impl ApiSubdomain {
     }
 }
 
-/// Resolves the API base URL from environment variables.
-///
-/// Priority:
-/// 1. `MEMORI_ENTERPRISE_PRODUCTION_DOMAIN` → `https://{subdomain}.{domain}`
-/// 2. `MEMORI_ENTERPRISE_STAGING_DOMAIN`    → `https://staging-{subdomain}.{domain}`
-/// 3. `MEMORI_API_URL_BASE`                 → verbatim (backward compat)
-/// 4. `MEMORI_TEST_MODE=1`                  → `https://staging-{subdomain}.memorilabs.ai`
-/// 5. Default                               → `https://{subdomain}.memorilabs.ai`
-pub fn resolve_base_url(subdomain: &ApiSubdomain) -> String {
-    let prefix = subdomain.as_str();
-
-    if let Ok(domain) = env::var("MEMORI_ENTERPRISE_PRODUCTION_DOMAIN") {
-        let domain = domain.trim().to_string();
-        if !domain.is_empty() {
-            return format!("https://{}.{}", prefix, domain);
-        }
-    }
-
-    if let Ok(domain) = env::var("MEMORI_ENTERPRISE_STAGING_DOMAIN") {
-        let domain = domain.trim().to_string();
-        if !domain.is_empty() {
-            return format!("https://staging-{}.{}", prefix, domain);
-        }
-    }
-
-    if let Ok(url) = env::var("MEMORI_API_URL_BASE") {
-        let url = url.trim().to_string();
-        if !url.is_empty() {
-            return url;
-        }
-    }
-
-    let test_mode = env::var("MEMORI_TEST_MODE").unwrap_or_default() == "1";
-    if test_mode {
-        format!("https://staging-{}.memorilabs.ai", prefix)
-    } else {
-        format!("https://{}.memorilabs.ai", prefix)
-    }
-}
-
-/// Resolves the X-Memori-API-Key from environment variables.
-///
-/// Returns the production key for enterprise production and default production,
-/// the staging key for all other cases. Always respects `MEMORI_X_API_KEY` override.
-pub fn resolve_x_api_key() -> String {
-    let override_key = env::var("MEMORI_X_API_KEY");
-
-    let enterprise_prod = env::var("MEMORI_ENTERPRISE_PRODUCTION_DOMAIN")
-        .map(|d| !d.trim().is_empty())
-        .unwrap_or(false);
-
-    if enterprise_prod {
-        return override_key.unwrap_or_else(|_| PUBLIC_PROD_KEY.to_string());
-    }
-
-    let uses_staging = env::var("MEMORI_ENTERPRISE_STAGING_DOMAIN")
-        .map(|d| !d.trim().is_empty())
-        .unwrap_or(false)
-        || env::var("MEMORI_API_URL_BASE")
-            .map(|u| !u.trim().is_empty())
-            .unwrap_or(false)
-        || env::var("MEMORI_TEST_MODE").unwrap_or_default() == "1";
-
-    if uses_staging {
-        override_key.unwrap_or_else(|_| PUBLIC_STAGING_KEY.to_string())
-    } else {
-        override_key.unwrap_or_else(|_| PUBLIC_PROD_KEY.to_string())
-    }
-}
-
 #[derive(Clone)]
 pub struct MemoriClient {
     client: Client,
@@ -106,8 +36,37 @@ pub struct MemoriClient {
 impl MemoriClient {
     /// Initializes the client from environment variables.
     pub fn new(subdomain: ApiSubdomain) -> Result<Self, ApiError> {
-        let base_url = resolve_base_url(&subdomain);
-        let x_api_key = resolve_x_api_key();
+        let prefix = subdomain.as_str();
+        let is_staging = env::var("MEMORI_ENV").unwrap_or_default() == "staging";
+
+        let (base_url, x_api_key) = {
+            let x_key = env::var("MEMORI_X_API_KEY");
+
+            if let Ok(domain) = env::var("MEMORI_DOMAIN") {
+                let domain = domain.trim().to_string();
+                if !domain.is_empty() {
+                    let url = if is_staging {
+                        format!("https://staging-{}.{}", prefix, domain)
+                    } else {
+                        format!("https://{}.{}", prefix, domain)
+                    };
+                    let key = x_key.unwrap_or_else(|_| {
+                        if is_staging {
+                            PUBLIC_STAGING_KEY
+                        } else {
+                            PUBLIC_PROD_KEY
+                        }
+                        .to_string()
+                    });
+                    (url, key)
+                } else {
+                    Self::resolve_fallback(prefix, is_staging, x_key)
+                }
+            } else {
+                Self::resolve_fallback(prefix, is_staging, x_key)
+            }
+        };
+
         let api_key = env::var("MEMORI_API_KEY").ok();
 
         let client = Client::builder()
@@ -121,6 +80,33 @@ impl MemoriClient {
             x_api_key,
             api_key,
         })
+    }
+
+    fn resolve_fallback(
+        prefix: &str,
+        is_staging: bool,
+        x_key: Result<String, env::VarError>,
+    ) -> (String, String) {
+        if let Ok(url) = env::var("MEMORI_API_URL_BASE") {
+            let url = url.trim().to_string();
+            if !url.is_empty() {
+                let key = x_key.unwrap_or_else(|_| PUBLIC_STAGING_KEY.to_string());
+                return (url, key);
+            }
+        }
+        let key = x_key.unwrap_or_else(|_| {
+            if is_staging {
+                PUBLIC_STAGING_KEY
+            } else {
+                PUBLIC_PROD_KEY
+            }
+            .to_string()
+        });
+        if is_staging {
+            (format!("https://staging-{}.memorilabs.ai", prefix), key)
+        } else {
+            (format!("https://{}.memorilabs.ai", prefix), key)
+        }
     }
 
     fn url(&self, route: &str) -> String {

--- a/core/src/network/mod.rs
+++ b/core/src/network/mod.rs
@@ -1,5 +1,5 @@
 pub mod client;
 pub mod error;
 
-pub use client::{ApiSubdomain, MemoriClient, resolve_base_url, resolve_x_api_key};
+pub use client::{ApiSubdomain, MemoriClient};
 pub use error::ApiError;

--- a/core/src/network/mod.rs
+++ b/core/src/network/mod.rs
@@ -1,5 +1,5 @@
 pub mod client;
 pub mod error;
 
-pub use client::{ApiSubdomain, MemoriClient};
+pub use client::{ApiSubdomain, MemoriClient, resolve_base_url, resolve_x_api_key};
 pub use error::ApiError;

--- a/examples/sqlite/rust_core_main.py
+++ b/examples/sqlite/rust_core_main.py
@@ -21,7 +21,7 @@ def main() -> None:
     if not openai_api_key:
         raise RuntimeError("Set OPENAI_API_KEY before running this example.")
 
-    os.environ["MEMORI_TEST_MODE"] = "1"
+    os.environ["MEMORI_ENV"] = "staging"
 
     client = OpenAI(api_key=openai_api_key, timeout=30.0)
     engine = create_engine("sqlite:///memori_rust_core.db")

--- a/integrations/claude-code/.env.example
+++ b/integrations/claude-code/.env.example
@@ -22,3 +22,6 @@ MEMORI_ENTITY_ID=your_entity_id_here
 
 # Optional: Process attribution for advanced-augmentation.
 # MEMORI_PROCESS_ID=your_process_id_here
+
+# Optional: Memori API base URL override. Defaults to production when unset.
+# MEMORI_API_URL_BASE=https://api.memorilabs.ai

--- a/integrations/claude-code/index.ts
+++ b/integrations/claude-code/index.ts
@@ -25,6 +25,7 @@
  *                     default session_id so retrieval stays project-scoped
  *                     across new Claude Code sessions and /clear.
  *   MEMORI_PROCESS_ID (optional) process attribution
+ *   MEMORI_API_URL_BASE (optional) Memori API base URL override
  *
  * --projectId and --sessionId override the defaults per call.
  *
@@ -94,9 +95,25 @@ const DEFAULT_PROJECT_ID =
 
 const DEFAULT_SESSION_ID = process.env.MEMORI_SESSION_ID ?? CLAUDE_SESSION_ID;
 
-const BASE_URL = "https://api.memorilabs.ai/v1";
-const COLLECTOR_URL = "https://collector.memorilabs.ai/v1";
-const X_API_KEY = "96a7ea3e-11c2-428c-b9ae-5a168363dc80";
+const PUBLIC_PROD_KEY = "96a7ea3e-11c2-428c-b9ae-5a168363dc80";
+const PUBLIC_STAGING_KEY = "c18b1022-7fe2-42af-ab01-b1f9139184f0";
+
+function env(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+  return value || undefined;
+}
+
+function versionedBaseUrl(baseUrl: string): string {
+  const trimmed = baseUrl.replace(/\/+$/, "");
+  return trimmed.endsWith("/v1") ? trimmed : `${trimmed}/v1`;
+}
+
+const API_URL_BASE = env("MEMORI_API_URL_BASE");
+const BASE_URL = versionedBaseUrl(API_URL_BASE ?? "https://api.memorilabs.ai");
+const COLLECTOR_URL = versionedBaseUrl(
+  API_URL_BASE ?? "https://collector.memorilabs.ai"
+);
+const X_API_KEY = API_URL_BASE ? PUBLIC_STAGING_KEY : PUBLIC_PROD_KEY;
 
 type HttpMethod = "GET" | "POST";
 

--- a/memori-ts/examples/sqlite/rust_core_main.ts
+++ b/memori-ts/examples/sqlite/rust_core_main.ts
@@ -17,7 +17,7 @@ async function main(): Promise<void> {
     throw new Error('Set OPENAI_API_KEY before running this example.');
   }
 
-  process.env.MEMORI_TEST_MODE = '1';
+  process.env.MEMORI_ENV = 'staging';
 
   const client = new OpenAI({ apiKey: openaiApiKey, timeout: 30_000 });
   const db = new Database('memori_rust_core.db');

--- a/memori-ts/src/core/config.ts
+++ b/memori-ts/src/core/config.ts
@@ -73,22 +73,23 @@ export class Config {
   public storage?: StorageManager;
 
   constructor() {
-    this.testMode = getEnv('MEMORI_ENV') === 'staging';
+    const envPrefix = getEnv('MEMORI_ENV')?.trim() ?? '';
+    this.testMode = envPrefix !== '';
 
     const domain = getEnv('MEMORI_DOMAIN')?.trim();
     if (domain) {
-      this.baseUrl = this.testMode ? `https://staging-api.${domain}` : `https://api.${domain}`;
-      this.xApiKey = this.testMode ? PUBLIC_STAGING_KEY : PUBLIC_PROD_KEY;
+      this.baseUrl = envPrefix ? `https://${envPrefix}-api.${domain}` : `https://api.${domain}`;
+      this.xApiKey = envPrefix ? PUBLIC_STAGING_KEY : PUBLIC_PROD_KEY;
     } else {
       const envUrl = getEnv('MEMORI_API_URL_BASE');
       if (envUrl) {
         this.baseUrl = envUrl;
         this.xApiKey = PUBLIC_STAGING_KEY;
       } else {
-        this.baseUrl = this.testMode
-          ? 'https://staging-api.memorilabs.ai'
+        this.baseUrl = envPrefix
+          ? `https://${envPrefix}-api.memorilabs.ai`
           : 'https://api.memorilabs.ai';
-        this.xApiKey = this.testMode ? PUBLIC_STAGING_KEY : PUBLIC_PROD_KEY;
+        this.xApiKey = envPrefix ? PUBLIC_STAGING_KEY : PUBLIC_PROD_KEY;
       }
     }
 

--- a/memori-ts/src/core/config.ts
+++ b/memori-ts/src/core/config.ts
@@ -1,5 +1,9 @@
+import { createRequire } from 'node:module';
 import { randomUUID } from 'node:crypto';
 import type { StorageManager } from '../storage/manager.js';
+
+const PUBLIC_PROD_KEY = '96a7ea3e-11c2-428c-b9ae-5a168363dc80';
+const PUBLIC_STAGING_KEY = 'c18b1022-7fe2-42af-ab01-b1f9139184f0';
 
 /**
  * Utility to safely retrieve environment variables across Node.js and other runtimes.
@@ -23,6 +27,11 @@ export class Config {
    * Automatically switches between production and staging based on `testMode`.
    */
   public baseUrl: string;
+
+  /**
+   * The X-Memori-API-Key header value derived from the active environment.
+   */
+  public xApiKey: string;
 
   /**
    * Whether the SDK is running in test/staging mode.
@@ -67,13 +76,52 @@ export class Config {
   constructor() {
     this.testMode = getEnv('MEMORI_TEST_MODE') === '1';
 
-    const envUrl = getEnv('MEMORI_API_URL_BASE');
-    this.baseUrl =
-      envUrl ?? (this.testMode ? 'https://staging-api.memorilabs.ai' : 'https://api.memorilabs.ai');
+    // Delegate URL and key resolution to Rust so the enterprise domain env vars
+    // have a single source of truth. Falls back to reading env vars directly
+    // when native bindings are unavailable (e.g. unit tests).
+    try {
+      const require = createRequire(import.meta.url);
+      const native = require('../native/index.js') as {
+        resolveApiBaseUrl: (subdomain: string) => string;
+        resolveXApiKey: () => string;
+      };
+      this.baseUrl = native.resolveApiBaseUrl('api');
+      this.xApiKey = native.resolveXApiKey();
+    } catch {
+      this.baseUrl = this._resolveBaseUrlFallback();
+      this.xApiKey = this._resolveXApiKeyFallback();
+    }
 
     this.apiKey = getEnv('MEMORI_API_KEY') ?? null;
     this.sessionId = randomUUID();
     this.recallRelevanceThreshold = 0.1;
     this.timeout = 30000;
+  }
+
+  // Mirrors Rust resolve_base_url — used only when native bindings are unavailable.
+  private _resolveBaseUrlFallback(): string {
+    const enterpriseProd = getEnv('MEMORI_ENTERPRISE_PRODUCTION_DOMAIN')?.trim();
+    if (enterpriseProd) return `https://api.${enterpriseProd}`;
+
+    const enterpriseStaging = getEnv('MEMORI_ENTERPRISE_STAGING_DOMAIN')?.trim();
+    if (enterpriseStaging) return `https://staging-api.${enterpriseStaging}`;
+
+    const envUrl = getEnv('MEMORI_API_URL_BASE');
+    if (envUrl) return envUrl;
+
+    return this.testMode ? 'https://staging-api.memorilabs.ai' : 'https://api.memorilabs.ai';
+  }
+
+  // Mirrors Rust resolve_x_api_key — used only when native bindings are unavailable.
+  private _resolveXApiKeyFallback(): string {
+    const enterpriseProd = getEnv('MEMORI_ENTERPRISE_PRODUCTION_DOMAIN')?.trim();
+    if (enterpriseProd) return PUBLIC_PROD_KEY;
+
+    const usesStaging =
+      !!getEnv('MEMORI_ENTERPRISE_STAGING_DOMAIN')?.trim() ||
+      !!getEnv('MEMORI_API_URL_BASE') ||
+      this.testMode;
+
+    return usesStaging ? PUBLIC_STAGING_KEY : PUBLIC_PROD_KEY;
   }
 }

--- a/memori-ts/src/core/config.ts
+++ b/memori-ts/src/core/config.ts
@@ -22,8 +22,8 @@ export class Config {
   public apiKey: string | null;
 
   /**
-   * The base URL for the Memori API.
-   * Automatically switches between production and staging based on `testMode`.
+   * The base URL for the Memori API (always the `api` subdomain).
+   * Use `resolveUrl(subdomain)` to get the URL for a specific subdomain.
    */
   public baseUrl: string;
 
@@ -33,8 +33,8 @@ export class Config {
   public xApiKey: string;
 
   /**
-   * Whether the SDK is running in staging mode.
-   * Defaults to `true` if `MEMORI_ENV` is set to 'staging'.
+   * Whether the SDK is running in a non-production environment.
+   * True when `MEMORI_ENV` is set to any non-empty value.
    */
   public testMode: boolean;
 
@@ -72,30 +72,43 @@ export class Config {
    */
   public storage?: StorageManager;
 
-  constructor() {
-    const envPrefix = getEnv('MEMORI_ENV')?.trim() ?? '';
-    this.testMode = envPrefix !== '';
+  private readonly _envPrefix: string;
+  private readonly _domain: string | undefined;
+  private readonly _apiUrlBase: string | undefined;
 
-    const domain = getEnv('MEMORI_DOMAIN')?.trim();
-    if (domain) {
-      this.baseUrl = envPrefix ? `https://${envPrefix}-api.${domain}` : `https://api.${domain}`;
-      this.xApiKey = envPrefix ? PUBLIC_STAGING_KEY : PUBLIC_PROD_KEY;
-    } else {
-      const envUrl = getEnv('MEMORI_API_URL_BASE');
-      if (envUrl) {
-        this.baseUrl = envUrl;
-        this.xApiKey = PUBLIC_STAGING_KEY;
-      } else {
-        this.baseUrl = envPrefix
-          ? `https://${envPrefix}-api.memorilabs.ai`
-          : 'https://api.memorilabs.ai';
-        this.xApiKey = envPrefix ? PUBLIC_STAGING_KEY : PUBLIC_PROD_KEY;
-      }
-    }
+  constructor() {
+    this._envPrefix = getEnv('MEMORI_ENV')?.trim() ?? '';
+    this._domain = getEnv('MEMORI_DOMAIN')?.trim() || undefined;
+    this._apiUrlBase = getEnv('MEMORI_API_URL_BASE') || undefined;
+
+    this.testMode = this._envPrefix !== '';
+    this.baseUrl = this.resolveUrl('api');
+    this.xApiKey =
+      this._domain || !this._apiUrlBase
+        ? this._envPrefix
+          ? PUBLIC_STAGING_KEY
+          : PUBLIC_PROD_KEY
+        : PUBLIC_STAGING_KEY;
 
     this.apiKey = getEnv('MEMORI_API_KEY') ?? null;
     this.sessionId = randomUUID();
     this.recallRelevanceThreshold = 0.1;
     this.timeout = 30000;
+  }
+
+  /**
+   * Builds the full base URL for the given subdomain (e.g. `'api'`, `'collector'`).
+   * Mirrors the Python `_resolve_api_config` logic.
+   */
+  public resolveUrl(subdomain: string): string {
+    if (this._domain) {
+      return this._envPrefix
+        ? `https://${this._envPrefix}-${subdomain}.${this._domain}`
+        : `https://${subdomain}.${this._domain}`;
+    }
+    if (this._apiUrlBase) return this._apiUrlBase;
+    return this._envPrefix
+      ? `https://${this._envPrefix}-${subdomain}.memorilabs.ai`
+      : `https://${subdomain}.memorilabs.ai`;
   }
 }

--- a/memori-ts/src/core/config.ts
+++ b/memori-ts/src/core/config.ts
@@ -1,4 +1,3 @@
-import { createRequire } from 'node:module';
 import { randomUUID } from 'node:crypto';
 import type { StorageManager } from '../storage/manager.js';
 
@@ -34,8 +33,8 @@ export class Config {
   public xApiKey: string;
 
   /**
-   * Whether the SDK is running in test/staging mode.
-   * Defaults to `true` if `MEMORI_TEST_MODE` is set to '1'.
+   * Whether the SDK is running in staging mode.
+   * Defaults to `true` if `MEMORI_ENV` is set to 'staging'.
    */
   public testMode: boolean;
 
@@ -74,54 +73,28 @@ export class Config {
   public storage?: StorageManager;
 
   constructor() {
-    this.testMode = getEnv('MEMORI_TEST_MODE') === '1';
+    this.testMode = getEnv('MEMORI_ENV') === 'staging';
 
-    // Delegate URL and key resolution to Rust so the enterprise domain env vars
-    // have a single source of truth. Falls back to reading env vars directly
-    // when native bindings are unavailable (e.g. unit tests).
-    try {
-      const require = createRequire(import.meta.url);
-      const native = require('../native/index.js') as {
-        resolveApiBaseUrl: (subdomain: string) => string;
-        resolveXApiKey: () => string;
-      };
-      this.baseUrl = native.resolveApiBaseUrl('api');
-      this.xApiKey = native.resolveXApiKey();
-    } catch {
-      this.baseUrl = this._resolveBaseUrlFallback();
-      this.xApiKey = this._resolveXApiKeyFallback();
+    const domain = getEnv('MEMORI_DOMAIN')?.trim();
+    if (domain) {
+      this.baseUrl = this.testMode ? `https://staging-api.${domain}` : `https://api.${domain}`;
+      this.xApiKey = this.testMode ? PUBLIC_STAGING_KEY : PUBLIC_PROD_KEY;
+    } else {
+      const envUrl = getEnv('MEMORI_API_URL_BASE');
+      if (envUrl) {
+        this.baseUrl = envUrl;
+        this.xApiKey = PUBLIC_STAGING_KEY;
+      } else {
+        this.baseUrl = this.testMode
+          ? 'https://staging-api.memorilabs.ai'
+          : 'https://api.memorilabs.ai';
+        this.xApiKey = this.testMode ? PUBLIC_STAGING_KEY : PUBLIC_PROD_KEY;
+      }
     }
 
     this.apiKey = getEnv('MEMORI_API_KEY') ?? null;
     this.sessionId = randomUUID();
     this.recallRelevanceThreshold = 0.1;
     this.timeout = 30000;
-  }
-
-  // Mirrors Rust resolve_base_url — used only when native bindings are unavailable.
-  private _resolveBaseUrlFallback(): string {
-    const enterpriseProd = getEnv('MEMORI_ENTERPRISE_PRODUCTION_DOMAIN')?.trim();
-    if (enterpriseProd) return `https://api.${enterpriseProd}`;
-
-    const enterpriseStaging = getEnv('MEMORI_ENTERPRISE_STAGING_DOMAIN')?.trim();
-    if (enterpriseStaging) return `https://staging-api.${enterpriseStaging}`;
-
-    const envUrl = getEnv('MEMORI_API_URL_BASE');
-    if (envUrl) return envUrl;
-
-    return this.testMode ? 'https://staging-api.memorilabs.ai' : 'https://api.memorilabs.ai';
-  }
-
-  // Mirrors Rust resolve_x_api_key — used only when native bindings are unavailable.
-  private _resolveXApiKeyFallback(): string {
-    const enterpriseProd = getEnv('MEMORI_ENTERPRISE_PRODUCTION_DOMAIN')?.trim();
-    if (enterpriseProd) return PUBLIC_PROD_KEY;
-
-    const usesStaging =
-      !!getEnv('MEMORI_ENTERPRISE_STAGING_DOMAIN')?.trim() ||
-      !!getEnv('MEMORI_API_URL_BASE') ||
-      this.testMode;
-
-    return usesStaging ? PUBLIC_STAGING_KEY : PUBLIC_PROD_KEY;
   }
 }

--- a/memori-ts/src/core/network.ts
+++ b/memori-ts/src/core/network.ts
@@ -12,9 +12,6 @@ export enum ApiSubdomain {
   COLLECTOR = 'collector',
 }
 
-const PUBLIC_PROD_KEY = '96a7ea3e-11c2-428c-b9ae-5a168363dc80';
-const PUBLIC_STAGING_KEY = 'c18b1022-7fe2-42af-ab01-b1f9139184f0';
-
 interface FetchOptions extends RequestInit {
   maxRetries?: number;
 }
@@ -37,7 +34,7 @@ export class Api {
       this.baseUrl = this.config.baseUrl;
     }
 
-    this.xApiKey = this.config.testMode ? PUBLIC_STAGING_KEY : PUBLIC_PROD_KEY;
+    this.xApiKey = this.config.xApiKey;
   }
 
   private getHeaders(): HeadersInit {

--- a/memori-ts/src/core/network.ts
+++ b/memori-ts/src/core/network.ts
@@ -26,13 +26,8 @@ export class Api {
   constructor(config: Config, subdomain: ApiSubdomain = ApiSubdomain.DEFAULT) {
     this.config = config;
 
-    if (subdomain === ApiSubdomain.COLLECTOR) {
-      this.baseUrl = this.config.baseUrl
-        .replace('://api.', '://collector.')
-        .replace('://staging-api.', '://staging-collector.');
-    } else {
-      this.baseUrl = this.config.baseUrl;
-    }
+    this.baseUrl =
+      subdomain === ApiSubdomain.DEFAULT ? this.config.baseUrl : this.config.resolveUrl(subdomain);
 
     this.xApiKey = this.config.xApiKey;
   }

--- a/memori-ts/src/native/index.d.ts
+++ b/memori-ts/src/native/index.d.ts
@@ -97,7 +97,3 @@ export interface NapiRetrievalRequest {
 export interface NapiWriteAck {
   writtenOps: number
 }
-
-export declare function resolveApiBaseUrl(subdomain: string): string
-
-export declare function resolveXApiKey(): string

--- a/memori-ts/src/native/index.d.ts
+++ b/memori-ts/src/native/index.d.ts
@@ -97,3 +97,6 @@ export interface NapiRetrievalRequest {
 export interface NapiWriteAck {
   writtenOps: number
 }
+
+export declare function resolveApiBaseUrl(subdomain: string): string
+export declare function resolveXApiKey(): string

--- a/memori-ts/src/native/index.d.ts
+++ b/memori-ts/src/native/index.d.ts
@@ -99,4 +99,5 @@ export interface NapiWriteAck {
 }
 
 export declare function resolveApiBaseUrl(subdomain: string): string
+
 export declare function resolveXApiKey(): string

--- a/memori-ts/src/native/index.js
+++ b/memori-ts/src/native/index.js
@@ -577,5 +577,3 @@ if (!nativeBinding) {
 
 module.exports = nativeBinding
 module.exports.MemoriEngine = nativeBinding.MemoriEngine
-module.exports.resolveApiBaseUrl = nativeBinding.resolveApiBaseUrl
-module.exports.resolveXApiKey = nativeBinding.resolveXApiKey

--- a/memori-ts/src/native/index.js
+++ b/memori-ts/src/native/index.js
@@ -577,3 +577,5 @@ if (!nativeBinding) {
 
 module.exports = nativeBinding
 module.exports.MemoriEngine = nativeBinding.MemoriEngine
+module.exports.resolveApiBaseUrl = nativeBinding.resolveApiBaseUrl
+module.exports.resolveXApiKey = nativeBinding.resolveXApiKey

--- a/memori-ts/tests/core/config.test.ts
+++ b/memori-ts/tests/core/config.test.ts
@@ -51,25 +51,25 @@ describe('Config', () => {
 
   describe('tenant domain', () => {
     it('should use MEMORI_DOMAIN for production api subdomain', () => {
-      process.env.MEMORI_DOMAIN = 'linkedin.memorilabs.ai';
+      process.env.MEMORI_DOMAIN = 'acme.memorilabs.ai';
       const config = new Config();
-      expect(config.baseUrl).toBe('https://api.linkedin.memorilabs.ai');
+      expect(config.baseUrl).toBe('https://api.acme.memorilabs.ai');
       expect(config.xApiKey).toBe('96a7ea3e-11c2-428c-b9ae-5a168363dc80');
     });
 
     it('should use MEMORI_DOMAIN with env prefix when MEMORI_ENV=staging', () => {
-      process.env.MEMORI_DOMAIN = 'linkedin.memorilabs.ai';
+      process.env.MEMORI_DOMAIN = 'acme.memorilabs.ai';
       process.env.MEMORI_ENV = 'staging';
       const config = new Config();
-      expect(config.baseUrl).toBe('https://staging-api.linkedin.memorilabs.ai');
+      expect(config.baseUrl).toBe('https://staging-api.acme.memorilabs.ai');
       expect(config.xApiKey).toBe('c18b1022-7fe2-42af-ab01-b1f9139184f0');
     });
 
     it('should use MEMORI_DOMAIN with arbitrary env prefix when MEMORI_ENV=qa', () => {
-      process.env.MEMORI_DOMAIN = 'linkedin.memorilabs.ai';
+      process.env.MEMORI_DOMAIN = 'acme.memorilabs.ai';
       process.env.MEMORI_ENV = 'qa';
       const config = new Config();
-      expect(config.baseUrl).toBe('https://qa-api.linkedin.memorilabs.ai');
+      expect(config.baseUrl).toBe('https://qa-api.acme.memorilabs.ai');
       expect(config.xApiKey).toBe('c18b1022-7fe2-42af-ab01-b1f9139184f0');
     });
 

--- a/memori-ts/tests/core/config.test.ts
+++ b/memori-ts/tests/core/config.test.ts
@@ -7,6 +7,9 @@ describe('Config', () => {
   beforeEach(() => {
     vi.resetModules();
     process.env = { ...originalEnv };
+    delete process.env.MEMORI_ENV;
+    delete process.env.MEMORI_DOMAIN;
+    delete process.env.MEMORI_API_URL_BASE;
   });
 
   afterEach(() => {
@@ -19,8 +22,8 @@ describe('Config', () => {
     expect(config.apiKey).toBe('env-key');
   });
 
-  it('should use staging URL if test mode is enabled via env', () => {
-    process.env.MEMORI_TEST_MODE = '1';
+  it('should use staging URL when MEMORI_ENV=staging', () => {
+    process.env.MEMORI_ENV = 'staging';
     const config = new Config();
     expect(config.testMode).toBe(true);
     expect(config.baseUrl).toContain('staging-api');
@@ -33,36 +36,30 @@ describe('Config', () => {
   });
 
   it('should default to production URL if no env vars set', () => {
-    delete process.env.MEMORI_TEST_MODE;
+    delete process.env.MEMORI_ENV;
     delete process.env.MEMORI_API_URL_BASE;
     const config = new Config();
     expect(config.baseUrl).toBe('https://api.memorilabs.ai');
   });
 
-  describe('enterprise domain', () => {
-    it('should use enterprise production domain for api subdomain', () => {
-      process.env.MEMORI_ENTERPRISE_PRODUCTION_DOMAIN = 'linkedin.memorilabs.ai';
+  describe('tenant domain', () => {
+    it('should use MEMORI_DOMAIN for production api subdomain', () => {
+      process.env.MEMORI_DOMAIN = 'linkedin.memorilabs.ai';
       const config = new Config();
       expect(config.baseUrl).toBe('https://api.linkedin.memorilabs.ai');
       expect(config.xApiKey).toBe('96a7ea3e-11c2-428c-b9ae-5a168363dc80');
     });
 
-    it('should use enterprise staging domain with staging prefix', () => {
-      process.env.MEMORI_ENTERPRISE_STAGING_DOMAIN = 'linkedin.memorilabs.ai';
+    it('should use MEMORI_DOMAIN with staging prefix when MEMORI_ENV=staging', () => {
+      process.env.MEMORI_DOMAIN = 'linkedin.memorilabs.ai';
+      process.env.MEMORI_ENV = 'staging';
       const config = new Config();
       expect(config.baseUrl).toBe('https://staging-api.linkedin.memorilabs.ai');
       expect(config.xApiKey).toBe('c18b1022-7fe2-42af-ab01-b1f9139184f0');
     });
 
-    it('should prefer enterprise production domain over staging domain', () => {
-      process.env.MEMORI_ENTERPRISE_PRODUCTION_DOMAIN = 'acme.memorilabs.ai';
-      process.env.MEMORI_ENTERPRISE_STAGING_DOMAIN = 'acme.memorilabs.ai';
-      const config = new Config();
-      expect(config.baseUrl).toBe('https://api.acme.memorilabs.ai');
-    });
-
-    it('should prefer enterprise production domain over MEMORI_API_URL_BASE', () => {
-      process.env.MEMORI_ENTERPRISE_PRODUCTION_DOMAIN = 'acme.memorilabs.ai';
+    it('should prefer MEMORI_DOMAIN over MEMORI_API_URL_BASE', () => {
+      process.env.MEMORI_DOMAIN = 'acme.memorilabs.ai';
       process.env.MEMORI_API_URL_BASE = 'https://custom.api.com';
       const config = new Config();
       expect(config.baseUrl).toBe('https://api.acme.memorilabs.ai');

--- a/memori-ts/tests/core/config.test.ts
+++ b/memori-ts/tests/core/config.test.ts
@@ -1,12 +1,20 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Config } from '../../src/core/config.js';
 
+const ENTERPRISE_VARS = [
+  'MEMORI_ENTERPRISE_PRODUCTION_DOMAIN',
+  'MEMORI_ENTERPRISE_STAGING_DOMAIN',
+  'MEMORI_API_URL_BASE',
+  'MEMORI_TEST_MODE',
+];
+
 describe('Config', () => {
   const originalEnv = process.env;
 
   beforeEach(() => {
     vi.resetModules();
     process.env = { ...originalEnv };
+    ENTERPRISE_VARS.forEach((v) => delete process.env[v]);
   });
 
   afterEach(() => {
@@ -33,9 +41,37 @@ describe('Config', () => {
   });
 
   it('should default to production URL if no env vars set', () => {
-    delete process.env.MEMORI_TEST_MODE;
-    delete process.env.MEMORI_API_URL_BASE;
     const config = new Config();
     expect(config.baseUrl).toBe('https://api.memorilabs.ai');
+  });
+
+  describe('enterprise domain', () => {
+    it('should use enterprise production domain for api subdomain', () => {
+      process.env.MEMORI_ENTERPRISE_PRODUCTION_DOMAIN = 'linkedin.memorilabs.ai';
+      const config = new Config();
+      expect(config.baseUrl).toBe('https://api.linkedin.memorilabs.ai');
+      expect(config.xApiKey).toBe('96a7ea3e-11c2-428c-b9ae-5a168363dc80');
+    });
+
+    it('should use enterprise staging domain with staging prefix', () => {
+      process.env.MEMORI_ENTERPRISE_STAGING_DOMAIN = 'linkedin.memorilabs.ai';
+      const config = new Config();
+      expect(config.baseUrl).toBe('https://staging-api.linkedin.memorilabs.ai');
+      expect(config.xApiKey).toBe('c18b1022-7fe2-42af-ab01-b1f9139184f0');
+    });
+
+    it('should prefer enterprise production domain over staging domain', () => {
+      process.env.MEMORI_ENTERPRISE_PRODUCTION_DOMAIN = 'acme.memorilabs.ai';
+      process.env.MEMORI_ENTERPRISE_STAGING_DOMAIN = 'acme.memorilabs.ai';
+      const config = new Config();
+      expect(config.baseUrl).toBe('https://api.acme.memorilabs.ai');
+    });
+
+    it('should prefer enterprise production domain over MEMORI_API_URL_BASE', () => {
+      process.env.MEMORI_ENTERPRISE_PRODUCTION_DOMAIN = 'acme.memorilabs.ai';
+      process.env.MEMORI_API_URL_BASE = 'https://custom.api.com';
+      const config = new Config();
+      expect(config.baseUrl).toBe('https://api.acme.memorilabs.ai');
+    });
   });
 });

--- a/memori-ts/tests/core/config.test.ts
+++ b/memori-ts/tests/core/config.test.ts
@@ -1,20 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Config } from '../../src/core/config.js';
 
-const ENTERPRISE_VARS = [
-  'MEMORI_ENTERPRISE_PRODUCTION_DOMAIN',
-  'MEMORI_ENTERPRISE_STAGING_DOMAIN',
-  'MEMORI_API_URL_BASE',
-  'MEMORI_TEST_MODE',
-];
-
 describe('Config', () => {
   const originalEnv = process.env;
 
   beforeEach(() => {
     vi.resetModules();
     process.env = { ...originalEnv };
-    ENTERPRISE_VARS.forEach((v) => delete process.env[v]);
   });
 
   afterEach(() => {
@@ -41,6 +33,8 @@ describe('Config', () => {
   });
 
   it('should default to production URL if no env vars set', () => {
+    delete process.env.MEMORI_TEST_MODE;
+    delete process.env.MEMORI_API_URL_BASE;
     const config = new Config();
     expect(config.baseUrl).toBe('https://api.memorilabs.ai');
   });

--- a/memori-ts/tests/core/config.test.ts
+++ b/memori-ts/tests/core/config.test.ts
@@ -22,11 +22,18 @@ describe('Config', () => {
     expect(config.apiKey).toBe('env-key');
   });
 
-  it('should use staging URL when MEMORI_ENV=staging', () => {
+  it('should use env prefix in URL when MEMORI_ENV is set', () => {
     process.env.MEMORI_ENV = 'staging';
     const config = new Config();
     expect(config.testMode).toBe(true);
-    expect(config.baseUrl).toContain('staging-api');
+    expect(config.baseUrl).toBe('https://staging-api.memorilabs.ai');
+  });
+
+  it('should use arbitrary env prefix when MEMORI_ENV=qa', () => {
+    process.env.MEMORI_ENV = 'qa';
+    const config = new Config();
+    expect(config.testMode).toBe(true);
+    expect(config.baseUrl).toBe('https://qa-api.memorilabs.ai');
   });
 
   it('should allow overriding base URL via environment', () => {
@@ -50,11 +57,19 @@ describe('Config', () => {
       expect(config.xApiKey).toBe('96a7ea3e-11c2-428c-b9ae-5a168363dc80');
     });
 
-    it('should use MEMORI_DOMAIN with staging prefix when MEMORI_ENV=staging', () => {
+    it('should use MEMORI_DOMAIN with env prefix when MEMORI_ENV=staging', () => {
       process.env.MEMORI_DOMAIN = 'linkedin.memorilabs.ai';
       process.env.MEMORI_ENV = 'staging';
       const config = new Config();
       expect(config.baseUrl).toBe('https://staging-api.linkedin.memorilabs.ai');
+      expect(config.xApiKey).toBe('c18b1022-7fe2-42af-ab01-b1f9139184f0');
+    });
+
+    it('should use MEMORI_DOMAIN with arbitrary env prefix when MEMORI_ENV=qa', () => {
+      process.env.MEMORI_DOMAIN = 'linkedin.memorilabs.ai';
+      process.env.MEMORI_ENV = 'qa';
+      const config = new Config();
+      expect(config.baseUrl).toBe('https://qa-api.linkedin.memorilabs.ai');
       expect(config.xApiKey).toBe('c18b1022-7fe2-42af-ab01-b1f9139184f0');
     });
 

--- a/memori-ts/tests/core/network.test.ts
+++ b/memori-ts/tests/core/network.test.ts
@@ -34,9 +34,30 @@ describe('Api Class', () => {
     vi.useRealTimers();
   });
 
-  it('should initialize with the correct collector subdomain', () => {
-    const collectorApi = new Api(config, ApiSubdomain.COLLECTOR);
-    expect(collectorApi).toBeDefined();
+  it('should resolve collector URL for public production', () => {
+    delete process.env.MEMORI_ENV;
+    delete process.env.MEMORI_DOMAIN;
+    const prodConfig = new Config();
+    const collectorApi = new Api(prodConfig, ApiSubdomain.COLLECTOR);
+    expect((collectorApi as any).baseUrl).toBe('https://collector.memorilabs.ai');
+  });
+
+  it('should resolve collector URL for staging env', () => {
+    process.env.MEMORI_ENV = 'staging';
+    const stagingConfig = new Config();
+    const collectorApi = new Api(stagingConfig, ApiSubdomain.COLLECTOR);
+    expect((collectorApi as any).baseUrl).toBe('https://staging-collector.memorilabs.ai');
+    delete process.env.MEMORI_ENV;
+  });
+
+  it('should resolve collector URL for arbitrary env prefix with tenant domain', () => {
+    process.env.MEMORI_ENV = 'qa';
+    process.env.MEMORI_DOMAIN = 'acme.memorilabs.ai';
+    const qaConfig = new Config();
+    const collectorApi = new Api(qaConfig, ApiSubdomain.COLLECTOR);
+    expect((collectorApi as any).baseUrl).toBe('https://qa-collector.acme.memorilabs.ai');
+    delete process.env.MEMORI_ENV;
+    delete process.env.MEMORI_DOMAIN;
   });
 
   it('should make a successful GET request', async () => {

--- a/memori/_config.py
+++ b/memori/_config.py
@@ -104,7 +104,7 @@ class Config:
         self.version = version("memori")
 
     def is_test_mode(self):
-        return os.environ.get("MEMORI_ENV") == "staging"
+        return bool(os.environ.get("MEMORI_ENV", "").strip())
 
     def reset_cache(self):
         self.cache = Cache()

--- a/memori/_config.py
+++ b/memori/_config.py
@@ -104,7 +104,7 @@ class Config:
         self.version = version("memori")
 
     def is_test_mode(self):
-        return os.environ.get("MEMORI_TEST_MODE", None) is not None
+        return os.environ.get("MEMORI_ENV") == "staging"
 
     def reset_cache(self):
         self.cache = Cache()

--- a/memori/_network.py
+++ b/memori/_network.py
@@ -12,7 +12,6 @@ import asyncio
 import logging
 import os
 import ssl
-import sys
 from enum import Enum
 
 import aiohttp
@@ -37,29 +36,19 @@ _PUBLIC_STAGING_KEY = "c18b1022-7fe2-42af-ab01-b1f9139184f0"
 
 
 def _resolve_api_config(subdomain_value: str) -> tuple[str, str]:
-    """Returns (base_url, x_api_key). Delegates to Rust when available."""
-    mp = sys.modules.get("memori_python")
-    if mp is not None and hasattr(mp, "resolve_api_base_url"):
-        return mp.resolve_api_base_url(subdomain_value), mp.resolve_x_api_key()
+    is_staging = os.environ.get("MEMORI_ENV") == "staging"
 
-    # Fallback mirrors Rust resolution order (used in test environments without Rust binary).
-    enterprise_prod = os.environ.get("MEMORI_ENTERPRISE_PRODUCTION_DOMAIN", "").strip()
-    if enterprise_prod:
-        return f"https://{subdomain_value}.{enterprise_prod}", _PUBLIC_PROD_KEY
-
-    enterprise_staging = os.environ.get("MEMORI_ENTERPRISE_STAGING_DOMAIN", "").strip()
-    if enterprise_staging:
-        return (
-            f"https://staging-{subdomain_value}.{enterprise_staging}",
-            _PUBLIC_STAGING_KEY,
-        )
+    domain = os.environ.get("MEMORI_DOMAIN", "").strip()
+    if domain:
+        if is_staging:
+            return f"https://staging-{subdomain_value}.{domain}", _PUBLIC_STAGING_KEY
+        return f"https://{subdomain_value}.{domain}", _PUBLIC_PROD_KEY
 
     custom_url = os.environ.get("MEMORI_API_URL_BASE", "").strip()
     if custom_url:
         return custom_url, _PUBLIC_STAGING_KEY
 
-    test_mode = os.environ.get("MEMORI_TEST_MODE") == "1"
-    if test_mode:
+    if is_staging:
         return f"https://staging-{subdomain_value}.memorilabs.ai", _PUBLIC_STAGING_KEY
 
     return f"https://{subdomain_value}.memorilabs.ai", _PUBLIC_PROD_KEY
@@ -72,7 +61,13 @@ class ApiSubdomain(str, Enum):
 
 class Api:
     def __init__(self, config: Config, subdomain: ApiSubdomain = ApiSubdomain.DEFAULT):
-        self.__base, self.__x_api_key = _resolve_api_config(subdomain.value)
+        env_base = os.environ.get("MEMORI_API_URL_BASE", "").strip()
+        if config.api_url_base and config.api_url_base != env_base:
+            # Programmatic base_url — takes precedence over env vars
+            self.__base = config.api_url_base
+            self.__x_api_key = _PUBLIC_STAGING_KEY
+        else:
+            self.__base, self.__x_api_key = _resolve_api_config(subdomain.value)
         self.config = config
 
     async def augmentation_async(self, payload: dict) -> dict:

--- a/memori/_network.py
+++ b/memori/_network.py
@@ -12,6 +12,7 @@ import asyncio
 import logging
 import os
 import ssl
+import sys
 from enum import Enum
 
 import aiohttp
@@ -31,6 +32,38 @@ from memori._exceptions import (
 
 logger = logging.getLogger(__name__)
 
+_PUBLIC_PROD_KEY = "96a7ea3e-11c2-428c-b9ae-5a168363dc80"
+_PUBLIC_STAGING_KEY = "c18b1022-7fe2-42af-ab01-b1f9139184f0"
+
+
+def _resolve_api_config(subdomain_value: str) -> tuple[str, str]:
+    """Returns (base_url, x_api_key). Delegates to Rust when available."""
+    mp = sys.modules.get("memori_python")
+    if mp is not None and hasattr(mp, "resolve_api_base_url"):
+        return mp.resolve_api_base_url(subdomain_value), mp.resolve_x_api_key()
+
+    # Fallback mirrors Rust resolution order (used in test environments without Rust binary).
+    enterprise_prod = os.environ.get("MEMORI_ENTERPRISE_PRODUCTION_DOMAIN", "").strip()
+    if enterprise_prod:
+        return f"https://{subdomain_value}.{enterprise_prod}", _PUBLIC_PROD_KEY
+
+    enterprise_staging = os.environ.get("MEMORI_ENTERPRISE_STAGING_DOMAIN", "").strip()
+    if enterprise_staging:
+        return (
+            f"https://staging-{subdomain_value}.{enterprise_staging}",
+            _PUBLIC_STAGING_KEY,
+        )
+
+    custom_url = os.environ.get("MEMORI_API_URL_BASE", "").strip()
+    if custom_url:
+        return custom_url, _PUBLIC_STAGING_KEY
+
+    test_mode = os.environ.get("MEMORI_TEST_MODE") == "1"
+    if test_mode:
+        return f"https://staging-{subdomain_value}.memorilabs.ai", _PUBLIC_STAGING_KEY
+
+    return f"https://{subdomain_value}.memorilabs.ai", _PUBLIC_PROD_KEY
+
 
 class ApiSubdomain(str, Enum):
     DEFAULT = "api"
@@ -39,23 +72,7 @@ class ApiSubdomain(str, Enum):
 
 class Api:
     def __init__(self, config: Config, subdomain: ApiSubdomain = ApiSubdomain.DEFAULT):
-        test_mode = os.environ.get("MEMORI_TEST_MODE") == "1"
-
-        self.__base = config.api_url_base or os.environ.get("MEMORI_API_URL_BASE")
-
-        if self.__base is None:
-            if test_mode:
-                # Use staging for test mode
-                self.__x_api_key = "c18b1022-7fe2-42af-ab01-b1f9139184f0"
-                self.__base = f"https://staging-{subdomain.value}.memorilabs.ai"
-            else:
-                # Use production
-                self.__x_api_key = "96a7ea3e-11c2-428c-b9ae-5a168363dc80"
-                self.__base = f"https://{subdomain.value}.memorilabs.ai"
-        else:
-            # Custom URL provided, use staging key as default
-            self.__x_api_key = "c18b1022-7fe2-42af-ab01-b1f9139184f0"
-
+        self.__base, self.__x_api_key = _resolve_api_config(subdomain.value)
         self.config = config
 
     async def augmentation_async(self, payload: dict) -> dict:

--- a/memori/_network.py
+++ b/memori/_network.py
@@ -36,22 +36,23 @@ _PUBLIC_STAGING_KEY = "c18b1022-7fe2-42af-ab01-b1f9139184f0"
 
 
 def _resolve_api_config(subdomain_value: str) -> tuple[str, str]:
-    is_staging = os.environ.get("MEMORI_ENV") == "staging"
+    env_prefix = os.environ.get("MEMORI_ENV", "").strip()
+    is_production = not env_prefix
 
     domain = os.environ.get("MEMORI_DOMAIN", "").strip()
     if domain:
-        if is_staging:
-            return f"https://staging-{subdomain_value}.{domain}", _PUBLIC_STAGING_KEY
-        return f"https://{subdomain_value}.{domain}", _PUBLIC_PROD_KEY
+        if is_production:
+            return f"https://{subdomain_value}.{domain}", _PUBLIC_PROD_KEY
+        return f"https://{env_prefix}-{subdomain_value}.{domain}", _PUBLIC_STAGING_KEY
 
     custom_url = os.environ.get("MEMORI_API_URL_BASE", "").strip()
     if custom_url:
         return custom_url, _PUBLIC_STAGING_KEY
 
-    if is_staging:
-        return f"https://staging-{subdomain_value}.memorilabs.ai", _PUBLIC_STAGING_KEY
+    if is_production:
+        return f"https://{subdomain_value}.memorilabs.ai", _PUBLIC_PROD_KEY
 
-    return f"https://{subdomain_value}.memorilabs.ai", _PUBLIC_PROD_KEY
+    return f"https://{env_prefix}-{subdomain_value}.memorilabs.ai", _PUBLIC_STAGING_KEY
 
 
 class ApiSubdomain(str, Enum):

--- a/tests/integration/cloud/conftest.py
+++ b/tests/integration/cloud/conftest.py
@@ -13,18 +13,18 @@ requires_memori_api_key = pytest.mark.skipif(
 
 @pytest.fixture
 def cloud_test_mode():
-    """Set MEMORI_TEST_MODE=1 so cloud API calls hit staging.
+    """Set MEMORI_ENV=staging so cloud API calls hit staging.
 
     Production cloud-api.memorilabs.ai does not exist yet.
     Only staging-cloud-api.memorilabs.ai is live.
     """
-    original = os.environ.get("MEMORI_TEST_MODE")
-    os.environ["MEMORI_TEST_MODE"] = "1"
+    original = os.environ.get("MEMORI_ENV")
+    os.environ["MEMORI_ENV"] = "staging"
     yield
     if original is None:
-        os.environ.pop("MEMORI_TEST_MODE", None)
+        os.environ.pop("MEMORI_ENV", None)
     else:
-        os.environ["MEMORI_TEST_MODE"] = original
+        os.environ["MEMORI_ENV"] = original
 
 
 @pytest.fixture
@@ -33,7 +33,7 @@ def cloud_memori_instance(sqlite_session_factory, cloud_test_mode):
 
     Uses conn for local storage (conversation/message verification) but sets
     config.cloud = True so augmentation and recall hit the staging cloud API.
-    Requires MEMORI_API_KEY and MEMORI_TEST_MODE=1 (set automatically).
+    Requires MEMORI_API_KEY and MEMORI_ENV=staging (set automatically).
     """
     if not MEMORI_API_KEY:
         pytest.skip("MEMORI_API_KEY not set (required for cloud tests)")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -87,14 +87,14 @@ def sqlite_session_factory(tmp_path):
 
 
 @pytest.fixture
-def memori_test_mode():
-    original = os.environ.get("MEMORI_TEST_MODE")
-    os.environ["MEMORI_TEST_MODE"] = "1"
+def memori_staging_env():
+    original = os.environ.get("MEMORI_ENV")
+    os.environ["MEMORI_ENV"] = "staging"
     yield
     if original is None:
-        os.environ.pop("MEMORI_TEST_MODE", None)
+        os.environ.pop("MEMORI_ENV", None)
     else:
-        os.environ["MEMORI_TEST_MODE"] = original
+        os.environ["MEMORI_ENV"] = original
 
 
 @pytest.fixture
@@ -112,7 +112,7 @@ def async_openai_client(openai_api_key):
 
 
 @pytest.fixture
-def memori_instance(sqlite_session_factory, memori_test_mode):
+def memori_instance(sqlite_session_factory, memori_staging_env):
     from memori import Memori
 
     mem = Memori(conn=sqlite_session_factory)
@@ -382,7 +382,7 @@ def aa_payload_capture():
 
 @pytest.fixture
 def memori_instance_with_capture(
-    sqlite_session_factory, memori_test_mode, aa_payload_capture
+    sqlite_session_factory, memori_staging_env, aa_payload_capture
 ):
     from memori import Memori
 

--- a/tests/integration/databases/conftest.py
+++ b/tests/integration/databases/conftest.py
@@ -120,19 +120,19 @@ def mongodb_client():
 
 
 @pytest.fixture
-def memori_test_mode():
+def memori_staging_env():
     """Enable Memori test mode."""
-    original = os.environ.get("MEMORI_TEST_MODE")
-    os.environ["MEMORI_TEST_MODE"] = "1"
+    original = os.environ.get("MEMORI_ENV")
+    os.environ["MEMORI_ENV"] = "staging"
     yield
     if original is None:
-        os.environ.pop("MEMORI_TEST_MODE", None)
+        os.environ.pop("MEMORI_ENV", None)
     else:
-        os.environ["MEMORI_TEST_MODE"] = original
+        os.environ["MEMORI_ENV"] = original
 
 
 @pytest.fixture
-def sqlite_memori(sqlite_session_factory, memori_test_mode):
+def sqlite_memori(sqlite_session_factory, memori_staging_env):
     """Create a Memori instance with SQLite backend."""
     from memori import Memori
 
@@ -146,7 +146,7 @@ def sqlite_memori(sqlite_session_factory, memori_test_mode):
 
 
 @pytest.fixture
-def postgres_memori(postgres_session_factory, memori_test_mode):
+def postgres_memori(postgres_session_factory, memori_staging_env):
     """Create a Memori instance with PostgreSQL backend."""
     from memori import Memori
 
@@ -160,7 +160,7 @@ def postgres_memori(postgres_session_factory, memori_test_mode):
 
 
 @pytest.fixture
-def mysql_memori(mysql_session_factory, memori_test_mode):
+def mysql_memori(mysql_session_factory, memori_staging_env):
     """Create a Memori instance with MySQL backend."""
     from memori import Memori
 
@@ -174,7 +174,7 @@ def mysql_memori(mysql_session_factory, memori_test_mode):
 
 
 @pytest.fixture
-def mongodb_memori(mongodb_client, memori_test_mode):
+def mongodb_memori(mongodb_client, memori_staging_env):
     """Create a Memori instance with MongoDB backend."""
     from memori import Memori
 

--- a/tests/integration/test_aa_payload.py
+++ b/tests/integration/test_aa_payload.py
@@ -7,7 +7,7 @@ import pytest
 
 from tests.integration.conftest import requires_openai
 
-os.environ.setdefault("MEMORI_TEST_MODE", "1")
+os.environ.setdefault("MEMORI_ENV", "staging")
 
 MODEL = "gpt-4o-mini"
 MAX_TOKENS = 50
@@ -219,12 +219,12 @@ class TestAAEdgeCases:
 
 
 class TestTestModeConfiguration:
-    def test_memori_test_mode_is_enabled(self):
-        assert os.environ.get("MEMORI_TEST_MODE") == "1"
+    def test_memori_staging_env_is_enabled(self):
+        assert os.environ.get("MEMORI_ENV") == "staging"
 
     @requires_openai
     @pytest.mark.integration
     def test_memori_instance_in_test_mode(self, memori_instance):
-        assert os.environ.get("MEMORI_TEST_MODE") is not None
+        assert os.environ.get("MEMORI_ENV") is not None
         assert memori_instance is not None
         assert memori_instance.config is not None

--- a/tests/llm/clients/oss/agno/anthropic_async.py
+++ b/tests/llm/clients/oss/agno/anthropic_async.py
@@ -12,7 +12,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("ANTHROPIC_API_KEY", None) is None:
     raise RuntimeError("ANTHROPIC_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 
 async def main():

--- a/tests/llm/clients/oss/agno/anthropic_sync.py
+++ b/tests/llm/clients/oss/agno/anthropic_sync.py
@@ -11,7 +11,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("ANTHROPIC_API_KEY", None) is None:
     raise RuntimeError("ANTHROPIC_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 session = TestDBSession
 model = Claude(id="claude-sonnet-4-20250514")

--- a/tests/llm/clients/oss/agno/gemini_async.py
+++ b/tests/llm/clients/oss/agno/gemini_async.py
@@ -12,7 +12,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("GEMINI_API_KEY", None) is None:
     raise RuntimeError("GEMINI_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 
 async def main():

--- a/tests/llm/clients/oss/agno/gemini_streaming.py
+++ b/tests/llm/clients/oss/agno/gemini_streaming.py
@@ -11,7 +11,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("GEMINI_API_KEY", None) is None:
     raise RuntimeError("GEMINI_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 session = TestDBSession
 model = Gemini(id="gemini-2.0-flash")

--- a/tests/llm/clients/oss/agno/gemini_sync.py
+++ b/tests/llm/clients/oss/agno/gemini_sync.py
@@ -11,7 +11,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("GEMINI_API_KEY", None) is None:
     raise RuntimeError("GEMINI_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 session = TestDBSession
 model = Gemini(id="gemini-2.0-flash-exp")

--- a/tests/llm/clients/oss/agno/openai_async.py
+++ b/tests/llm/clients/oss/agno/openai_async.py
@@ -12,7 +12,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("OPENAI_API_KEY", None) is None:
     raise RuntimeError("OPENAI_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 
 async def main():

--- a/tests/llm/clients/oss/agno/openai_streaming.py
+++ b/tests/llm/clients/oss/agno/openai_streaming.py
@@ -11,7 +11,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("OPENAI_API_KEY", None) is None:
     raise RuntimeError("OPENAI_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 session = TestDBSession
 model = OpenAIChat(id="gpt-4o-mini")

--- a/tests/llm/clients/oss/agno/openai_sync.py
+++ b/tests/llm/clients/oss/agno/openai_sync.py
@@ -11,7 +11,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("OPENAI_API_KEY", None) is None:
     raise RuntimeError("OPENAI_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 session = TestDBSession
 model = OpenAIChat(id="gpt-4o-mini")

--- a/tests/llm/clients/oss/agno/xai_async.py
+++ b/tests/llm/clients/oss/agno/xai_async.py
@@ -12,7 +12,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("XAI_API_KEY", None) is None:
     raise RuntimeError("XAI_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 
 async def main():

--- a/tests/llm/clients/oss/agno/xai_streaming.py
+++ b/tests/llm/clients/oss/agno/xai_streaming.py
@@ -11,7 +11,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("XAI_API_KEY", None) is None:
     raise RuntimeError("XAI_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 session = TestDBSession
 model = xAI(id="grok-4")

--- a/tests/llm/clients/oss/agno/xai_sync.py
+++ b/tests/llm/clients/oss/agno/xai_sync.py
@@ -11,7 +11,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("XAI_API_KEY", None) is None:
     raise RuntimeError("XAI_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 session = TestDBSession
 model = xAI(id="grok-3")

--- a/tests/llm/clients/oss/anthropic/async.py
+++ b/tests/llm/clients/oss/anthropic/async.py
@@ -11,7 +11,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("ANTHROPIC_API_KEY", None) is None:
     raise RuntimeError("ANTHROPIC_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 
 async def run():

--- a/tests/llm/clients/oss/anthropic/sync.py
+++ b/tests/llm/clients/oss/anthropic/sync.py
@@ -10,7 +10,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("ANTHROPIC_API_KEY", None) is None:
     raise RuntimeError("ANTHROPIC_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 session = TestDBSession
 client = anthropic.Anthropic()

--- a/tests/llm/clients/oss/gemini/async.py
+++ b/tests/llm/clients/oss/gemini/async.py
@@ -11,7 +11,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("GEMINI_API_KEY", None) is None:
     raise RuntimeError("GEMINI_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 
 async def main():

--- a/tests/llm/clients/oss/gemini/async_streaming.py
+++ b/tests/llm/clients/oss/gemini/async_streaming.py
@@ -11,7 +11,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("GEMINI_API_KEY", None) is None:
     raise RuntimeError("GEMINI_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 
 async def main():

--- a/tests/llm/clients/oss/gemini/sync.py
+++ b/tests/llm/clients/oss/gemini/sync.py
@@ -10,7 +10,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("GEMINI_API_KEY", None) is None:
     raise RuntimeError("GEMINI_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 session = TestDBSession
 client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])

--- a/tests/llm/clients/oss/langchain/chatbedrock/async_runnable.py
+++ b/tests/llm/clients/oss/langchain/chatbedrock/async_runnable.py
@@ -13,7 +13,7 @@ from memori import Memori
 if os.environ.get("AWS_BEARER_TOKEN_BEDROCK", None) is None:
     raise RuntimeError("AWS_BEARER_TOKEN_BEDROCK is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 
 async def main():

--- a/tests/llm/clients/oss/langchain/chatgooglegenai/async_runnable.py
+++ b/tests/llm/clients/oss/langchain/chatgooglegenai/async_runnable.py
@@ -13,7 +13,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("GEMINI_API_KEY", None) is None:
     raise RuntimeError("GEMINI_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 
 async def main():

--- a/tests/llm/clients/oss/langchain/chatgooglegenai/async_streaming.py
+++ b/tests/llm/clients/oss/langchain/chatgooglegenai/async_streaming.py
@@ -12,7 +12,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("GEMINI_API_KEY", None) is None:
     raise RuntimeError("GEMINI_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 
 async def main():

--- a/tests/llm/clients/oss/langchain/chatgooglegenai/sync.py
+++ b/tests/llm/clients/oss/langchain/chatgooglegenai/sync.py
@@ -10,7 +10,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("GEMINI_API_KEY", None) is None:
     raise RuntimeError("GEMINI_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 session = TestDBSession
 client = ChatGoogleGenerativeAI(

--- a/tests/llm/clients/oss/langchain/chatgooglegenai/sync_runnable.py
+++ b/tests/llm/clients/oss/langchain/chatgooglegenai/sync_runnable.py
@@ -12,7 +12,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("GEMINI_API_KEY", None) is None:
     raise RuntimeError("GEMINI_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 
 session = TestDBSession

--- a/tests/llm/clients/oss/langchain/chatgooglegenai/sync_runnable_structured_output.py
+++ b/tests/llm/clients/oss/langchain/chatgooglegenai/sync_runnable_structured_output.py
@@ -12,7 +12,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("GEMINI_API_KEY", None) is None:
     raise RuntimeError("GEMINI_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 
 class Color(BaseModel):

--- a/tests/llm/clients/oss/langchain/chatopenai/async_ainvoke.py
+++ b/tests/llm/clients/oss/langchain/chatopenai/async_ainvoke.py
@@ -12,7 +12,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("OPENAI_API_KEY", None) is None:
     raise RuntimeError("OPENAI_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 
 async def run():

--- a/tests/llm/clients/oss/langchain/chatopenai/async_runnable.py
+++ b/tests/llm/clients/oss/langchain/chatopenai/async_runnable.py
@@ -13,7 +13,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("OPENAI_API_KEY", None) is None:
     raise RuntimeError("OPENAI_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 
 async def main():

--- a/tests/llm/clients/oss/langchain/chatopenai/async_streaming.py
+++ b/tests/llm/clients/oss/langchain/chatopenai/async_streaming.py
@@ -12,7 +12,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("OPENAI_API_KEY", None) is None:
     raise RuntimeError("OPENAI_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 
 async def main():

--- a/tests/llm/clients/oss/langchain/chatopenai/sync.py
+++ b/tests/llm/clients/oss/langchain/chatopenai/sync.py
@@ -10,7 +10,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("OPENAI_API_KEY", None) is None:
     raise RuntimeError("OPENAI_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 session = TestDBSession
 client = ChatOpenAI(model="gpt-4o-mini")

--- a/tests/llm/clients/oss/langchain/chatopenai/sync_runnable.py
+++ b/tests/llm/clients/oss/langchain/chatopenai/sync_runnable.py
@@ -12,7 +12,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("OPENAI_API_KEY", None) is None:
     raise RuntimeError("OPENAI_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 
 session = TestDBSession

--- a/tests/llm/clients/oss/langchain/chatopenai/sync_runnable_structured_output.py
+++ b/tests/llm/clients/oss/langchain/chatopenai/sync_runnable_structured_output.py
@@ -12,7 +12,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("OPENAI_API_KEY", None) is None:
     raise RuntimeError("OPENAI_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 
 class Color(BaseModel):

--- a/tests/llm/clients/oss/langchain/chatvertexai/sync.py
+++ b/tests/llm/clients/oss/langchain/chatvertexai/sync.py
@@ -10,7 +10,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", None) is None:
     raise RuntimeError("GOOGLE_APPLICATION_CREDENTIALS is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 session = TestDBSession
 client = ChatVertexAI(

--- a/tests/llm/clients/oss/openai/async.py
+++ b/tests/llm/clients/oss/openai/async.py
@@ -18,7 +18,7 @@ from tests.database.core import (
 if os.environ.get("OPENAI_API_KEY", None) is None:
     raise RuntimeError("OPENAI_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 
 async def run(db_backend: str = "default"):

--- a/tests/llm/clients/oss/openai/async_streaming.py
+++ b/tests/llm/clients/oss/openai/async_streaming.py
@@ -11,7 +11,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("OPENAI_API_KEY", None) is None:
     raise RuntimeError("OPENAI_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 
 async def run():

--- a/tests/llm/clients/oss/openai/sync.py
+++ b/tests/llm/clients/oss/openai/sync.py
@@ -10,7 +10,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("OPENAI_API_KEY", None) is None:
     raise RuntimeError("OPENAI_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 session = TestDBSession
 client = OpenAI()

--- a/tests/llm/clients/oss/xai/async.py
+++ b/tests/llm/clients/oss/xai/async.py
@@ -20,7 +20,7 @@ from tests.database.core import (
 if os.environ.get("XAI_API_KEY", None) is None:
     raise RuntimeError("XAI_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 
 async def run(db_backend: str = "default"):

--- a/tests/llm/clients/oss/xai/async_stream.py
+++ b/tests/llm/clients/oss/xai/async_stream.py
@@ -20,7 +20,7 @@ from tests.database.core import (
 if os.environ.get("XAI_API_KEY", None) is None:
     raise RuntimeError("XAI_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 
 async def run(db_backend: str = "default"):

--- a/tests/llm/clients/oss/xai/sync.py
+++ b/tests/llm/clients/oss/xai/sync.py
@@ -11,7 +11,7 @@ from tests.database.core import TestDBSession
 if os.environ.get("XAI_API_KEY", None) is None:
     raise RuntimeError("XAI_API_KEY is not set")
 
-os.environ["MEMORI_TEST_MODE"] = "1"
+os.environ["MEMORI_ENV"] = "staging"
 
 session = TestDBSession
 client = Client(api_key=os.environ.get("XAI_API_KEY"))

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -8,7 +8,7 @@ from memori import Memori
 def test_memori_accepts_programmatic_api_key(monkeypatch):
     monkeypatch.delenv("MEMORI_API_KEY", raising=False)
     monkeypatch.delenv("MEMORI_COCKROACHDB_CONNECTION_STRING", raising=False)
-    monkeypatch.setenv("MEMORI_TEST_MODE", "1")
+    monkeypatch.setenv("MEMORI_ENV", "staging")
 
     mem = Memori(api_key="programmatic-key")
 
@@ -19,7 +19,7 @@ def test_memori_accepts_programmatic_api_key(monkeypatch):
 def test_memori_accepts_programmatic_base_url(monkeypatch):
     monkeypatch.delenv("MEMORI_API_URL_BASE", raising=False)
     monkeypatch.delenv("MEMORI_COCKROACHDB_CONNECTION_STRING", raising=False)
-    monkeypatch.setenv("MEMORI_TEST_MODE", "1")
+    monkeypatch.setenv("MEMORI_ENV", "staging")
 
     mem = Memori(api_key="key", base_url="https://api.example.com")
 
@@ -35,7 +35,7 @@ def test_memori_accepts_programmatic_base_url(monkeypatch):
 
 def test_sync_api_uses_configured_timeout(monkeypatch, mocker):
     monkeypatch.delenv("MEMORI_COCKROACHDB_CONNECTION_STRING", raising=False)
-    monkeypatch.setenv("MEMORI_TEST_MODE", "1")
+    monkeypatch.setenv("MEMORI_ENV", "staging")
     mem = Memori(api_key="key")
     mem.config.request_secs_timeout = 12
 
@@ -59,7 +59,7 @@ def test_sync_api_uses_configured_timeout(monkeypatch, mocker):
 
 def test_agent_recall_builds_query_string(monkeypatch, mocker):
     monkeypatch.delenv("MEMORI_COCKROACHDB_CONNECTION_STRING", raising=False)
-    monkeypatch.setenv("MEMORI_TEST_MODE", "1")
+    monkeypatch.setenv("MEMORI_ENV", "staging")
     mem = Memori(api_key="key").attribution("entity", "process")
 
     get = mocker.patch.object(
@@ -91,7 +91,7 @@ def test_agent_recall_builds_query_string(monkeypatch, mocker):
 
 def test_agent_recall_rejects_session_without_project(monkeypatch):
     monkeypatch.delenv("MEMORI_COCKROACHDB_CONNECTION_STRING", raising=False)
-    monkeypatch.setenv("MEMORI_TEST_MODE", "1")
+    monkeypatch.setenv("MEMORI_ENV", "staging")
     mem = Memori(api_key="key")
 
     with pytest.raises(ValueError, match="session_id cannot be provided"):
@@ -100,7 +100,7 @@ def test_agent_recall_rejects_session_without_project(monkeypatch):
 
 def test_agent_recall_summary_builds_query_string(monkeypatch, mocker):
     monkeypatch.delenv("MEMORI_COCKROACHDB_CONNECTION_STRING", raising=False)
-    monkeypatch.setenv("MEMORI_TEST_MODE", "1")
+    monkeypatch.setenv("MEMORI_ENV", "staging")
     mem = Memori(api_key="key")
 
     get = mocker.patch.object(
@@ -119,7 +119,7 @@ def test_agent_recall_summary_builds_query_string(monkeypatch, mocker):
 
 def test_agent_compaction_builds_query_string(monkeypatch, mocker):
     monkeypatch.delenv("MEMORI_COCKROACHDB_CONNECTION_STRING", raising=False)
-    monkeypatch.setenv("MEMORI_TEST_MODE", "1")
+    monkeypatch.setenv("MEMORI_ENV", "staging")
     mem = Memori(api_key="key")
 
     get = mocker.patch.object(
@@ -142,7 +142,7 @@ def test_agent_compaction_builds_query_string(monkeypatch, mocker):
 
 def test_agent_compaction_requires_project(monkeypatch):
     monkeypatch.delenv("MEMORI_COCKROACHDB_CONNECTION_STRING", raising=False)
-    monkeypatch.setenv("MEMORI_TEST_MODE", "1")
+    monkeypatch.setenv("MEMORI_ENV", "staging")
     mem = Memori(api_key="key")
 
     with pytest.raises(ValueError, match="project_id is required"):
@@ -151,7 +151,7 @@ def test_agent_compaction_requires_project(monkeypatch):
 
 def test_capture_agent_turn_writes_turn_then_collector(monkeypatch, mocker):
     monkeypatch.delenv("MEMORI_COCKROACHDB_CONNECTION_STRING", raising=False)
-    monkeypatch.setenv("MEMORI_TEST_MODE", "1")
+    monkeypatch.setenv("MEMORI_ENV", "staging")
     mem = Memori(api_key="key").attribution("entity", "process")
     mem.set_session("session")
 
@@ -202,7 +202,7 @@ def test_capture_agent_turn_writes_turn_then_collector(monkeypatch, mocker):
 
 def test_capture_agent_turn_swallow_collector_failure(monkeypatch, mocker):
     monkeypatch.delenv("MEMORI_COCKROACHDB_CONNECTION_STRING", raising=False)
-    monkeypatch.setenv("MEMORI_TEST_MODE", "1")
+    monkeypatch.setenv("MEMORI_ENV", "staging")
     mem = Memori(api_key="key")
 
     default_post = mocker.patch.object(mem.agent.default_api, "post", return_value={})
@@ -223,7 +223,7 @@ def test_capture_agent_turn_swallow_collector_failure(monkeypatch, mocker):
 
 def test_agent_feedback_posts_content(monkeypatch, mocker):
     monkeypatch.delenv("MEMORI_COCKROACHDB_CONNECTION_STRING", raising=False)
-    monkeypatch.setenv("MEMORI_TEST_MODE", "1")
+    monkeypatch.setenv("MEMORI_ENV", "staging")
     mem = Memori(api_key="key")
 
     post = mocker.patch.object(mem.agent.default_api, "post", return_value={})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,6 +15,12 @@ def test_is_test_mode():
     finally:
         os.environ.pop("MEMORI_ENV", None)
 
+    try:
+        os.environ["MEMORI_ENV"] = "qa"
+        assert config.is_test_mode() is True
+    finally:
+        os.environ.pop("MEMORI_ENV", None)
+
 
 def test_reset_cache():
     config = Config()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,15 +5,15 @@ from memori._config import Config
 
 def test_is_test_mode():
     config = Config()
-    os.environ.pop("MEMORI_TEST_MODE", None)
+    os.environ.pop("MEMORI_ENV", None)
 
     assert config.is_test_mode() is False
 
     try:
-        os.environ["MEMORI_TEST_MODE"] = "1"
+        os.environ["MEMORI_ENV"] = "staging"
         assert config.is_test_mode() is True
     finally:
-        os.environ.pop("MEMORI_TEST_MODE", None)
+        os.environ.pop("MEMORI_ENV", None)
 
 
 def test_reset_cache():

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -55,7 +55,7 @@ def test_memori_use_rust_core_kwarg_false(mocker):
 def test_cloud_true_when_no_conn(monkeypatch):
     monkeypatch.delenv("MEMORI_COCKROACHDB_CONNECTION_STRING", raising=False)
     monkeypatch.setenv("MEMORI_API_KEY", "test-api-key")
-    monkeypatch.setenv("MEMORI_TEST_MODE", "1")
+    monkeypatch.setenv("MEMORI_ENV", "staging")
     mem = Memori()
     assert mem.config.cloud is True
 
@@ -211,7 +211,7 @@ def test_embed_texts_uses_config_defaults(mocker):
 def test_recall_defaults_to_config_limit_in_cloud(monkeypatch, mocker):
     monkeypatch.delenv("MEMORI_COCKROACHDB_CONNECTION_STRING", raising=False)
     monkeypatch.setenv("MEMORI_API_KEY", "test-api-key")
-    monkeypatch.setenv("MEMORI_TEST_MODE", "1")
+    monkeypatch.setenv("MEMORI_ENV", "staging")
 
     mem = Memori().attribution(entity_id="entity-id", process_id="process-id")
     mem.config.recall_facts_limit = 10
@@ -280,7 +280,7 @@ def test_delete_entity_memories_supported_in_explicit_conn_mode(mocker):
 def test_delete_entity_memories_rejected_in_cloud_mode(monkeypatch):
     monkeypatch.delenv("MEMORI_COCKROACHDB_CONNECTION_STRING", raising=False)
     monkeypatch.setenv("MEMORI_API_KEY", "test-api-key")
-    monkeypatch.setenv("MEMORI_TEST_MODE", "1")
+    monkeypatch.setenv("MEMORI_ENV", "staging")
     mem = Memori()
 
     with pytest.raises(RuntimeError) as e:

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -109,6 +109,79 @@ class TestApiInitialization:
             del os.environ["MEMORI_TEST_MODE"]
 
 
+class TestApiEnterpriseDomain:
+    _ENTERPRISE_VARS = (
+        "MEMORI_ENTERPRISE_PRODUCTION_DOMAIN",
+        "MEMORI_ENTERPRISE_STAGING_DOMAIN",
+        "MEMORI_API_URL_BASE",
+        "MEMORI_TEST_MODE",
+    )
+
+    def _clean_env(self):
+        for v in self._ENTERPRISE_VARS:
+            os.environ.pop(v, None)
+
+    def test_enterprise_production_domain_api(self):
+        self._clean_env()
+        os.environ["MEMORI_ENTERPRISE_PRODUCTION_DOMAIN"] = "linkedin.memorilabs.ai"
+        try:
+            api = Api(Config())
+            assert api._Api__base == "https://api.linkedin.memorilabs.ai"  # type: ignore[attr-defined]
+            assert api._Api__x_api_key == "96a7ea3e-11c2-428c-b9ae-5a168363dc80"  # type: ignore[attr-defined]
+        finally:
+            self._clean_env()
+
+    def test_enterprise_production_domain_collector(self):
+        self._clean_env()
+        os.environ["MEMORI_ENTERPRISE_PRODUCTION_DOMAIN"] = "linkedin.memorilabs.ai"
+        try:
+            api = Api(Config(), subdomain=ApiSubdomain.COLLECTOR)
+            assert api._Api__base == "https://collector.linkedin.memorilabs.ai"  # type: ignore[attr-defined]
+            assert api._Api__x_api_key == "96a7ea3e-11c2-428c-b9ae-5a168363dc80"  # type: ignore[attr-defined]
+        finally:
+            self._clean_env()
+
+    def test_enterprise_staging_domain_api(self):
+        self._clean_env()
+        os.environ["MEMORI_ENTERPRISE_STAGING_DOMAIN"] = "linkedin.memorilabs.ai"
+        try:
+            api = Api(Config())
+            assert api._Api__base == "https://staging-api.linkedin.memorilabs.ai"  # type: ignore[attr-defined]
+            assert api._Api__x_api_key == "c18b1022-7fe2-42af-ab01-b1f9139184f0"  # type: ignore[attr-defined]
+        finally:
+            self._clean_env()
+
+    def test_enterprise_staging_domain_collector(self):
+        self._clean_env()
+        os.environ["MEMORI_ENTERPRISE_STAGING_DOMAIN"] = "linkedin.memorilabs.ai"
+        try:
+            api = Api(Config(), subdomain=ApiSubdomain.COLLECTOR)
+            assert api._Api__base == "https://staging-collector.linkedin.memorilabs.ai"  # type: ignore[attr-defined]
+            assert api._Api__x_api_key == "c18b1022-7fe2-42af-ab01-b1f9139184f0"  # type: ignore[attr-defined]
+        finally:
+            self._clean_env()
+
+    def test_enterprise_production_takes_priority_over_staging(self):
+        self._clean_env()
+        os.environ["MEMORI_ENTERPRISE_PRODUCTION_DOMAIN"] = "acme.memorilabs.ai"
+        os.environ["MEMORI_ENTERPRISE_STAGING_DOMAIN"] = "acme.memorilabs.ai"
+        try:
+            api = Api(Config())
+            assert api._Api__base == "https://api.acme.memorilabs.ai"  # type: ignore[attr-defined]
+        finally:
+            self._clean_env()
+
+    def test_enterprise_production_takes_priority_over_api_url_base(self):
+        self._clean_env()
+        os.environ["MEMORI_ENTERPRISE_PRODUCTION_DOMAIN"] = "acme.memorilabs.ai"
+        os.environ["MEMORI_API_URL_BASE"] = "https://custom.api.com"
+        try:
+            api = Api(Config())
+            assert api._Api__base == "https://api.acme.memorilabs.ai"  # type: ignore[attr-defined]
+        finally:
+            self._clean_env()
+
+
 class TestApiUrl:
     def test_url_construction(self, api):
         assert api.url("test/route") == "https://test.api.com/v1/test/route"

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -67,7 +67,7 @@ class TestApiInitialization:
         assert api._Api__x_api_key == "c18b1022-7fe2-42af-ab01-b1f9139184f0"  # type: ignore[attr-defined]
         assert api._Api__base == "https://custom.api.com"  # type: ignore[attr-defined]
 
-    def test_init_uses_staging_when_memori_env_staging(self):
+    def test_init_uses_env_prefix_when_memori_env_set(self):
         os.environ.pop("MEMORI_API_URL_BASE", None)
         os.environ["MEMORI_ENV"] = "staging"
 
@@ -78,14 +78,14 @@ class TestApiInitialization:
         finally:
             del os.environ["MEMORI_ENV"]
 
-    def test_init_uses_staging_subdomain_when_memori_env_staging(self):
+    def test_init_uses_arbitrary_env_prefix(self):
         os.environ.pop("MEMORI_API_URL_BASE", None)
-        os.environ["MEMORI_ENV"] = "staging"
+        os.environ["MEMORI_ENV"] = "qa"
 
         try:
-            api = Api(Config(), subdomain=ApiSubdomain.DEFAULT)
+            api = Api(Config())
             assert api._Api__x_api_key == "c18b1022-7fe2-42af-ab01-b1f9139184f0"  # type: ignore[attr-defined]
-            assert api._Api__base == "https://staging-api.memorilabs.ai"  # type: ignore[attr-defined]
+            assert api._Api__base == "https://qa-api.memorilabs.ai"  # type: ignore[attr-defined]
         finally:
             del os.environ["MEMORI_ENV"]
 
@@ -143,6 +143,17 @@ class TestApiTenantDomain:
         try:
             api = Api(Config(), subdomain=ApiSubdomain.COLLECTOR)
             assert api._Api__base == "https://staging-collector.linkedin.memorilabs.ai"  # type: ignore[attr-defined]
+            assert api._Api__x_api_key == "c18b1022-7fe2-42af-ab01-b1f9139184f0"  # type: ignore[attr-defined]
+        finally:
+            self._clean_env()
+
+    def test_tenant_arbitrary_env_prefix(self):
+        self._clean_env()
+        os.environ["MEMORI_DOMAIN"] = "linkedin.memorilabs.ai"
+        os.environ["MEMORI_ENV"] = "qa"
+        try:
+            api = Api(Config())
+            assert api._Api__base == "https://qa-api.linkedin.memorilabs.ai"  # type: ignore[attr-defined]
             assert api._Api__x_api_key == "c18b1022-7fe2-42af-ab01-b1f9139184f0"  # type: ignore[attr-defined]
         finally:
             self._clean_env()

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -107,53 +107,53 @@ class TestApiTenantDomain:
 
     def test_tenant_production_api(self):
         self._clean_env()
-        os.environ["MEMORI_DOMAIN"] = "linkedin.memorilabs.ai"
+        os.environ["MEMORI_DOMAIN"] = "acme.memorilabs.ai"
         try:
             api = Api(Config())
-            assert api._Api__base == "https://api.linkedin.memorilabs.ai"  # type: ignore[attr-defined]
+            assert api._Api__base == "https://api.acme.memorilabs.ai"  # type: ignore[attr-defined]
             assert api._Api__x_api_key == "96a7ea3e-11c2-428c-b9ae-5a168363dc80"  # type: ignore[attr-defined]
         finally:
             self._clean_env()
 
     def test_tenant_production_collector(self):
         self._clean_env()
-        os.environ["MEMORI_DOMAIN"] = "linkedin.memorilabs.ai"
+        os.environ["MEMORI_DOMAIN"] = "acme.memorilabs.ai"
         try:
             api = Api(Config(), subdomain=ApiSubdomain.COLLECTOR)
-            assert api._Api__base == "https://collector.linkedin.memorilabs.ai"  # type: ignore[attr-defined]
+            assert api._Api__base == "https://collector.acme.memorilabs.ai"  # type: ignore[attr-defined]
             assert api._Api__x_api_key == "96a7ea3e-11c2-428c-b9ae-5a168363dc80"  # type: ignore[attr-defined]
         finally:
             self._clean_env()
 
     def test_tenant_staging_api(self):
         self._clean_env()
-        os.environ["MEMORI_DOMAIN"] = "linkedin.memorilabs.ai"
+        os.environ["MEMORI_DOMAIN"] = "acme.memorilabs.ai"
         os.environ["MEMORI_ENV"] = "staging"
         try:
             api = Api(Config())
-            assert api._Api__base == "https://staging-api.linkedin.memorilabs.ai"  # type: ignore[attr-defined]
+            assert api._Api__base == "https://staging-api.acme.memorilabs.ai"  # type: ignore[attr-defined]
             assert api._Api__x_api_key == "c18b1022-7fe2-42af-ab01-b1f9139184f0"  # type: ignore[attr-defined]
         finally:
             self._clean_env()
 
     def test_tenant_staging_collector(self):
         self._clean_env()
-        os.environ["MEMORI_DOMAIN"] = "linkedin.memorilabs.ai"
+        os.environ["MEMORI_DOMAIN"] = "acme.memorilabs.ai"
         os.environ["MEMORI_ENV"] = "staging"
         try:
             api = Api(Config(), subdomain=ApiSubdomain.COLLECTOR)
-            assert api._Api__base == "https://staging-collector.linkedin.memorilabs.ai"  # type: ignore[attr-defined]
+            assert api._Api__base == "https://staging-collector.acme.memorilabs.ai"  # type: ignore[attr-defined]
             assert api._Api__x_api_key == "c18b1022-7fe2-42af-ab01-b1f9139184f0"  # type: ignore[attr-defined]
         finally:
             self._clean_env()
 
     def test_tenant_arbitrary_env_prefix(self):
         self._clean_env()
-        os.environ["MEMORI_DOMAIN"] = "linkedin.memorilabs.ai"
+        os.environ["MEMORI_DOMAIN"] = "acme.memorilabs.ai"
         os.environ["MEMORI_ENV"] = "qa"
         try:
             api = Api(Config())
-            assert api._Api__base == "https://qa-api.linkedin.memorilabs.ai"  # type: ignore[attr-defined]
+            assert api._Api__base == "https://qa-api.acme.memorilabs.ai"  # type: ignore[attr-defined]
             assert api._Api__x_api_key == "c18b1022-7fe2-42af-ab01-b1f9139184f0"  # type: ignore[attr-defined]
         finally:
             self._clean_env()

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -45,85 +45,69 @@ class TestApiRetryRecoverable:
 
 class TestApiInitialization:
     def test_init_uses_default_api_key_and_base_url(self):
-        if "MEMORI_API_URL_BASE" in os.environ:
-            del os.environ["MEMORI_API_URL_BASE"]
-        if "MEMORI_TEST_MODE" in os.environ:
-            del os.environ["MEMORI_TEST_MODE"]
+        os.environ.pop("MEMORI_API_URL_BASE", None)
+        os.environ.pop("MEMORI_ENV", None)
 
         api = Api(Config())
         assert api._Api__x_api_key == "96a7ea3e-11c2-428c-b9ae-5a168363dc80"  # type: ignore[attr-defined]
         assert api._Api__base == "https://api.memorilabs.ai"  # type: ignore[attr-defined]
 
     def test_init_uses_custom_subdomain_base_url(self):
-        if "MEMORI_API_URL_BASE" in os.environ:
-            del os.environ["MEMORI_API_URL_BASE"]
-        if "MEMORI_TEST_MODE" in os.environ:
-            del os.environ["MEMORI_TEST_MODE"]
+        os.environ.pop("MEMORI_API_URL_BASE", None)
+        os.environ.pop("MEMORI_ENV", None)
 
         api = Api(Config(), subdomain=ApiSubdomain.COLLECTOR)
         assert api._Api__x_api_key == "96a7ea3e-11c2-428c-b9ae-5a168363dc80"  # type: ignore[attr-defined]
         assert api._Api__base == "https://collector.memorilabs.ai"  # type: ignore[attr-defined]
 
     def test_init_uses_custom_base_url(self):
-        if "MEMORI_TEST_MODE" in os.environ:
-            del os.environ["MEMORI_TEST_MODE"]
+        os.environ.pop("MEMORI_ENV", None)
         os.environ["MEMORI_API_URL_BASE"] = "https://custom.api.com"
         api = Api(Config())
         assert api._Api__x_api_key == "c18b1022-7fe2-42af-ab01-b1f9139184f0"  # type: ignore[attr-defined]
         assert api._Api__base == "https://custom.api.com"  # type: ignore[attr-defined]
 
-    def test_init_uses_staging_when_test_mode_enabled(self):
-        if "MEMORI_API_URL_BASE" in os.environ:
-            del os.environ["MEMORI_API_URL_BASE"]
-        os.environ["MEMORI_TEST_MODE"] = "1"
+    def test_init_uses_staging_when_memori_env_staging(self):
+        os.environ.pop("MEMORI_API_URL_BASE", None)
+        os.environ["MEMORI_ENV"] = "staging"
 
         try:
             api = Api(Config())
             assert api._Api__x_api_key == "c18b1022-7fe2-42af-ab01-b1f9139184f0"  # type: ignore[attr-defined]
             assert api._Api__base == "https://staging-api.memorilabs.ai"  # type: ignore[attr-defined]
         finally:
-            del os.environ["MEMORI_TEST_MODE"]
+            del os.environ["MEMORI_ENV"]
 
-    def test_init_uses_staging_subdomain_when_test_mode_enabled(self):
-        if "MEMORI_API_URL_BASE" in os.environ:
-            del os.environ["MEMORI_API_URL_BASE"]
-        os.environ["MEMORI_TEST_MODE"] = "1"
+    def test_init_uses_staging_subdomain_when_memori_env_staging(self):
+        os.environ.pop("MEMORI_API_URL_BASE", None)
+        os.environ["MEMORI_ENV"] = "staging"
 
         try:
             api = Api(Config(), subdomain=ApiSubdomain.DEFAULT)
             assert api._Api__x_api_key == "c18b1022-7fe2-42af-ab01-b1f9139184f0"  # type: ignore[attr-defined]
             assert api._Api__base == "https://staging-api.memorilabs.ai"  # type: ignore[attr-defined]
         finally:
-            del os.environ["MEMORI_TEST_MODE"]
+            del os.environ["MEMORI_ENV"]
 
-    def test_init_uses_production_when_test_mode_disabled(self):
-        if "MEMORI_API_URL_BASE" in os.environ:
-            del os.environ["MEMORI_API_URL_BASE"]
-        os.environ["MEMORI_TEST_MODE"] = "0"
+    def test_init_uses_production_by_default(self):
+        os.environ.pop("MEMORI_API_URL_BASE", None)
+        os.environ.pop("MEMORI_ENV", None)
 
-        try:
-            api = Api(Config())
-            assert api._Api__x_api_key == "96a7ea3e-11c2-428c-b9ae-5a168363dc80"  # type: ignore[attr-defined]
-            assert api._Api__base == "https://api.memorilabs.ai"  # type: ignore[attr-defined]
-        finally:
-            del os.environ["MEMORI_TEST_MODE"]
+        api = Api(Config())
+        assert api._Api__x_api_key == "96a7ea3e-11c2-428c-b9ae-5a168363dc80"  # type: ignore[attr-defined]
+        assert api._Api__base == "https://api.memorilabs.ai"  # type: ignore[attr-defined]
 
 
-class TestApiEnterpriseDomain:
-    _ENTERPRISE_VARS = (
-        "MEMORI_ENTERPRISE_PRODUCTION_DOMAIN",
-        "MEMORI_ENTERPRISE_STAGING_DOMAIN",
-        "MEMORI_API_URL_BASE",
-        "MEMORI_TEST_MODE",
-    )
+class TestApiTenantDomain:
+    _VARS = ("MEMORI_DOMAIN", "MEMORI_ENV", "MEMORI_API_URL_BASE")
 
     def _clean_env(self):
-        for v in self._ENTERPRISE_VARS:
+        for v in self._VARS:
             os.environ.pop(v, None)
 
-    def test_enterprise_production_domain_api(self):
+    def test_tenant_production_api(self):
         self._clean_env()
-        os.environ["MEMORI_ENTERPRISE_PRODUCTION_DOMAIN"] = "linkedin.memorilabs.ai"
+        os.environ["MEMORI_DOMAIN"] = "linkedin.memorilabs.ai"
         try:
             api = Api(Config())
             assert api._Api__base == "https://api.linkedin.memorilabs.ai"  # type: ignore[attr-defined]
@@ -131,9 +115,9 @@ class TestApiEnterpriseDomain:
         finally:
             self._clean_env()
 
-    def test_enterprise_production_domain_collector(self):
+    def test_tenant_production_collector(self):
         self._clean_env()
-        os.environ["MEMORI_ENTERPRISE_PRODUCTION_DOMAIN"] = "linkedin.memorilabs.ai"
+        os.environ["MEMORI_DOMAIN"] = "linkedin.memorilabs.ai"
         try:
             api = Api(Config(), subdomain=ApiSubdomain.COLLECTOR)
             assert api._Api__base == "https://collector.linkedin.memorilabs.ai"  # type: ignore[attr-defined]
@@ -141,9 +125,10 @@ class TestApiEnterpriseDomain:
         finally:
             self._clean_env()
 
-    def test_enterprise_staging_domain_api(self):
+    def test_tenant_staging_api(self):
         self._clean_env()
-        os.environ["MEMORI_ENTERPRISE_STAGING_DOMAIN"] = "linkedin.memorilabs.ai"
+        os.environ["MEMORI_DOMAIN"] = "linkedin.memorilabs.ai"
+        os.environ["MEMORI_ENV"] = "staging"
         try:
             api = Api(Config())
             assert api._Api__base == "https://staging-api.linkedin.memorilabs.ai"  # type: ignore[attr-defined]
@@ -151,9 +136,10 @@ class TestApiEnterpriseDomain:
         finally:
             self._clean_env()
 
-    def test_enterprise_staging_domain_collector(self):
+    def test_tenant_staging_collector(self):
         self._clean_env()
-        os.environ["MEMORI_ENTERPRISE_STAGING_DOMAIN"] = "linkedin.memorilabs.ai"
+        os.environ["MEMORI_DOMAIN"] = "linkedin.memorilabs.ai"
+        os.environ["MEMORI_ENV"] = "staging"
         try:
             api = Api(Config(), subdomain=ApiSubdomain.COLLECTOR)
             assert api._Api__base == "https://staging-collector.linkedin.memorilabs.ai"  # type: ignore[attr-defined]
@@ -161,19 +147,9 @@ class TestApiEnterpriseDomain:
         finally:
             self._clean_env()
 
-    def test_enterprise_production_takes_priority_over_staging(self):
+    def test_tenant_domain_takes_priority_over_api_url_base(self):
         self._clean_env()
-        os.environ["MEMORI_ENTERPRISE_PRODUCTION_DOMAIN"] = "acme.memorilabs.ai"
-        os.environ["MEMORI_ENTERPRISE_STAGING_DOMAIN"] = "acme.memorilabs.ai"
-        try:
-            api = Api(Config())
-            assert api._Api__base == "https://api.acme.memorilabs.ai"  # type: ignore[attr-defined]
-        finally:
-            self._clean_env()
-
-    def test_enterprise_production_takes_priority_over_api_url_base(self):
-        self._clean_env()
-        os.environ["MEMORI_ENTERPRISE_PRODUCTION_DOMAIN"] = "acme.memorilabs.ai"
+        os.environ["MEMORI_DOMAIN"] = "acme.memorilabs.ai"
         os.environ["MEMORI_API_URL_BASE"] = "https://custom.api.com"
         try:
             api = Api(Config())


### PR DESCRIPTION
Adds support for single-tenant, private VPC deployments across the Python and TypeScript SDKs. Also replaces `MEMORI_TEST_MODE` with the more intuitive `MEMORI_ENV` across the board.

### What changed

- **Python SDK** — `_network.py` reads `MEMORI_DOMAIN` and `MEMORI_ENV` directly to resolve the base URL and API key. `Config.is_test_mode()` returns `true` for any non-empty `MEMORI_ENV`.
- **TypeScript SDK** — `Config` reads the same vars. `testMode` is `true` for any non-empty `MEMORI_ENV`. `xApiKey` is now a first-class `Config` property used by `network.ts`.
- **Rust core** — `MemoriClient` updated to the same resolution logic for internal API calls.
- **`MEMORI_TEST_MODE`** fully replaced by `MEMORI_ENV` across the SDK, Makefile, CI, tests, and examples.

### How it works

`MEMORI_ENV` is used as a subdomain prefix — any value works, not just `staging`:

MEMORI_ENV=staging  →  staging-api.memorilabs.ai
MEMORI_ENV=qa       →  qa-api.memorilabs.ai
MEMORI_ENV=dev      →  dev-api.memorilabs.ai
(unset)             →  api.memorilabs.ai



Combined with `MEMORI_DOMAIN` for enterprise VPCs:

MEMORI_DOMAIN=acme.memorilabs.ai
MEMORI_ENV=staging  →  staging-api.acme.memorilabs.ai
(unset)             →  api.acme.memorilabs.ai



### Customer .env

MEMORI_DOMAIN=acme.memorilabs.ai   # enterprise VPC (omit for public cloud)
MEMORI_ENV=staging                     # omit for production
MEMORI_API_KEY=their-api-key



### Backward compatible
`MEMORI_API_URL_BASE` still works as before. Customers not setting any of the new vars see zero change in behavior.