### PR TITLE
Enhance Hermes Memori integration with improved path resolution and d…

### DIFF
--- a/docs/memori-cloud/hermes/quickstart.mdx
+++ b/docs/memori-cloud/hermes/quickstart.mdx
@@ -28,7 +28,9 @@ hermes-memori install
 
 Install `hermes-memori` in the same Python environment that Hermes uses.
 The `hermes-memori install` command registers the provider in Hermes' memory
-plugin directory at `$HERMES_HOME/plugins/memori`.
+plugin directory under `plugins/memori`. It honors `--hermes-home` and
+`HERMES_HOME`, uses Hermes' own home resolver when available, then falls back to
+`%LOCALAPPDATA%\hermes` on Windows or `~/.hermes` on POSIX systems.
 
 ## 2. Configure
 

--- a/docs/memori-cloud/hermes/quickstart.mdx
+++ b/docs/memori-cloud/hermes/quickstart.mdx
@@ -29,8 +29,9 @@ hermes-memori install
 Install `hermes-memori` in the same Python environment that Hermes uses.
 The `hermes-memori install` command registers the provider in Hermes' memory
 plugin directory under `plugins/memori`. It honors `--hermes-home` and
-`HERMES_HOME`, uses Hermes' own home resolver when available, then falls back to
-`%LOCALAPPDATA%\hermes` on Windows or `~/.hermes` on POSIX systems.
+otherwise uses Hermes' own home resolver when available, including active
+profile overrides. If Hermes is not importable, it falls back to `HERMES_HOME`,
+`%LOCALAPPDATA%\hermes` on Windows, or `~/.hermes` on POSIX systems.
 
 ## 2. Configure
 

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -178,8 +178,9 @@ hermes-memori install --force
 
 The `hermes-memori install` command registers the provider in Hermes' active
 memory plugin directory under `plugins/memori`. It honors `--hermes-home` and
-`HERMES_HOME`, uses Hermes' own home resolver when available, then falls back to
-the Windows `%LOCALAPPDATA%\hermes` default or `~/.hermes` on POSIX systems.
+otherwise uses Hermes' own home resolver when available, including active
+profile overrides. If Hermes is not importable, it falls back to `HERMES_HOME`,
+the Windows `%LOCALAPPDATA%\hermes` default, or `~/.hermes` on POSIX systems.
 
 ### 2. Configure
 

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -176,9 +176,10 @@ pip install -e integrations/hermes
 hermes-memori install --force
 ```
 
-The `hermes-memori install` command registers the provider in Hermes' memory
-plugin directory at `$HERMES_HOME/plugins/memori`, which is where Hermes scans
-for user-installed memory providers.
+The `hermes-memori install` command registers the provider in Hermes' active
+memory plugin directory under `plugins/memori`. It honors `--hermes-home` and
+`HERMES_HOME`, uses Hermes' own home resolver when available, then falls back to
+the Windows `%LOCALAPPDATA%\hermes` default or `~/.hermes` on POSIX systems.
 
 ### 2. Configure
 

--- a/integrations/hermes/plugin.yaml
+++ b/integrations/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: memori
-version: 0.1.7
+version: 0.1.8
 description: Structured long-term memory for Hermes Agent using Memori Cloud.
 pip_dependencies:
   - memori>=3.3.3

--- a/integrations/hermes/plugin.yaml
+++ b/integrations/hermes/plugin.yaml
@@ -2,6 +2,6 @@ name: memori
 version: 0.1.7
 description: Structured long-term memory for Hermes Agent using Memori Cloud.
 pip_dependencies:
-  - memori
+  - memori>=3.3.3
 hooks:
   - on_session_end

--- a/integrations/hermes/pyproject.toml
+++ b/integrations/hermes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-memori"
-version = "0.1.7"
+version = "0.1.8"
 description = "Official Memori Labs provider for Hermes Agent, enabling structured long-term memory from agent trace and execution."
 authors = [{name = "Memori Labs Team", email = "noc@memorilabs.ai"}]
 license = "Apache-2.0"

--- a/integrations/hermes/src/memori_hermes/__init__.py
+++ b/integrations/hermes/src/memori_hermes/__init__.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from ._paths import PLUGIN_NAME, config_path
 from .client import MemoriAgentClient, MemoriApiError
 from .tools import TOOL_SCHEMAS
 
@@ -23,7 +24,6 @@ except Exception:  # noqa: BLE001
 
 logger = logging.getLogger(__name__)
 
-PLUGIN_NAME = "memori"
 SYNC_JOIN_TIMEOUT_SECS = 5.0
 HERMES_PLATFORM = "hermes"
 
@@ -45,13 +45,8 @@ def _env(name: str) -> str | None:
     return value or None
 
 
-def _hermes_home_from_env() -> Path:
-    return Path(_env("HERMES_HOME") or "~/.hermes").expanduser()
-
-
 def _config_path(hermes_home: str | Path | None = None) -> Path:
-    base = Path(hermes_home).expanduser() if hermes_home else _hermes_home_from_env()
-    return base / "memori.json"
+    return config_path(hermes_home)
 
 
 def _read_file_config(hermes_home: str | Path | None = None) -> dict[str, Any]:

--- a/integrations/hermes/src/memori_hermes/_paths.py
+++ b/integrations/hermes/src/memori_hermes/_paths.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import sys
+from importlib import import_module
 from pathlib import Path
 
 PLUGIN_NAME = "memori"
@@ -12,8 +13,12 @@ PLUGIN_NAME = "memori"
 def _hermes_home_from_hermes() -> Path | None:
     """Return Hermes' own home path when Hermes is importable."""
     try:
-        from hermes_constants import get_hermes_home  # type: ignore[import-not-found]
+        hermes_constants = import_module("hermes_constants")
     except Exception:  # noqa: BLE001
+        return None
+
+    get_hermes_home = getattr(hermes_constants, "get_hermes_home", None)
+    if not callable(get_hermes_home):
         return None
     return Path(get_hermes_home()).expanduser()
 

--- a/integrations/hermes/src/memori_hermes/_paths.py
+++ b/integrations/hermes/src/memori_hermes/_paths.py
@@ -33,13 +33,13 @@ def resolve_hermes_home(hermes_home_path: str | Path | None = None) -> Path:
     if hermes_home_path:
         return Path(hermes_home_path).expanduser()
 
-    env_home = os.environ.get("HERMES_HOME", "").strip()
-    if env_home:
-        return Path(env_home).expanduser()
-
     hermes_home = _hermes_home_from_hermes()
     if hermes_home is not None:
         return hermes_home
+
+    env_home = os.environ.get("HERMES_HOME", "").strip()
+    if env_home:
+        return Path(env_home).expanduser()
 
     return _platform_default_hermes_home()
 

--- a/integrations/hermes/src/memori_hermes/_paths.py
+++ b/integrations/hermes/src/memori_hermes/_paths.py
@@ -1,0 +1,54 @@
+"""Path helpers shared by the Memori Hermes provider and installer."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+PLUGIN_NAME = "memori"
+
+
+def _hermes_home_from_hermes() -> Path | None:
+    """Return Hermes' own home path when Hermes is importable."""
+    try:
+        from hermes_constants import get_hermes_home  # type: ignore[import-not-found]
+    except Exception:  # noqa: BLE001
+        return None
+    return Path(get_hermes_home()).expanduser()
+
+
+def _platform_default_hermes_home() -> Path:
+    if sys.platform == "win32":
+        local_appdata = os.environ.get("LOCALAPPDATA", "").strip()
+        if local_appdata:
+            return Path(local_appdata).expanduser() / "hermes"
+        return Path.home() / "AppData" / "Local" / "hermes"
+
+    return Path("~/.hermes").expanduser()
+
+
+def resolve_hermes_home(hermes_home_path: str | Path | None = None) -> Path:
+    """Resolve the Hermes home directory using Hermes-compatible precedence."""
+    if hermes_home_path:
+        return Path(hermes_home_path).expanduser()
+
+    env_home = os.environ.get("HERMES_HOME", "").strip()
+    if env_home:
+        return Path(env_home).expanduser()
+
+    hermes_home = _hermes_home_from_hermes()
+    if hermes_home is not None:
+        return hermes_home
+
+    return _platform_default_hermes_home()
+
+
+def plugin_target_dir(hermes_home_path: str | Path | None = None) -> Path:
+    """Return the Hermes memory plugin destination for Memori."""
+    return resolve_hermes_home(hermes_home_path) / "plugins" / PLUGIN_NAME
+
+
+def config_path(hermes_home_path: str | Path | None = None) -> Path:
+    """Return the profile-scoped Memori config path used by the provider."""
+    return resolve_hermes_home(hermes_home_path) / "memori.json"

--- a/integrations/hermes/src/memori_hermes/install.py
+++ b/integrations/hermes/src/memori_hermes/install.py
@@ -3,14 +3,46 @@
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import shutil
 import sys
 from pathlib import Path
+from types import ModuleType
+from typing import Protocol, cast
+
+
+class _PathsModule(Protocol):
+    PLUGIN_NAME: str
+
+    def resolve_hermes_home(
+        self,
+        hermes_home_path: str | Path | None = None,
+    ) -> Path: ...
+
+    def plugin_target_dir(
+        self,
+        hermes_home_path: str | Path | None = None,
+    ) -> Path: ...
+
+
+def _load_direct_paths_module() -> ModuleType:
+    """Load _paths.py when this file is executed outside its package."""
+    paths_file = Path(__file__).resolve().with_name("_paths.py")
+    spec = importlib.util.spec_from_file_location("memori_hermes._paths", paths_file)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not load Hermes path helpers from {paths_file}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
 
 try:
-    from . import _paths
+    from . import _paths as _paths_module
 except ImportError:  # pragma: no cover - supports direct file execution.
-    import _paths  # type: ignore[no-redef]
+    _paths: _PathsModule = cast(_PathsModule, _load_direct_paths_module())
+else:
+    _paths = _paths_module
 
 PLUGIN_NAME = _paths.PLUGIN_NAME
 
@@ -85,8 +117,8 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--hermes-home",
         help=(
-            "Hermes home directory. Defaults to HERMES_HOME, Hermes' own "
-            "resolver, or the platform default."
+            "Hermes home directory. Defaults to Hermes' own resolver, "
+            "HERMES_HOME, or the platform default."
         ),
     )
 

--- a/integrations/hermes/src/memori_hermes/install.py
+++ b/integrations/hermes/src/memori_hermes/install.py
@@ -3,19 +3,24 @@
 from __future__ import annotations
 
 import argparse
-import os
 import shutil
 import sys
 from pathlib import Path
 
-PLUGIN_NAME = "memori"
+try:
+    from . import _paths
+except ImportError:  # pragma: no cover - supports direct file execution.
+    import _paths  # type: ignore[no-redef]
+
+PLUGIN_NAME = _paths.PLUGIN_NAME
+
 EXCLUDED_DIRS = {"__pycache__", ".pytest_cache", ".ruff_cache"}
 EXCLUDED_SUFFIXES = {".pyc", ".pyo"}
 
 
 def hermes_home() -> Path:
     """Return the Hermes home directory used for user-installed plugins."""
-    return Path(os.environ.get("HERMES_HOME") or "~/.hermes").expanduser()
+    return _paths.resolve_hermes_home()
 
 
 def plugin_source_dir() -> Path:
@@ -25,8 +30,7 @@ def plugin_source_dir() -> Path:
 
 def plugin_target_dir(hermes_home_path: str | Path | None = None) -> Path:
     """Return the Hermes memory plugin destination for Memori."""
-    base = Path(hermes_home_path).expanduser() if hermes_home_path else hermes_home()
-    return base / "plugins" / PLUGIN_NAME
+    return _paths.plugin_target_dir(hermes_home_path)
 
 
 def _ignore_copy_names(_directory: str, names: list[str]) -> set[str]:
@@ -80,7 +84,10 @@ def _parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--hermes-home",
-        help="Hermes home directory. Defaults to HERMES_HOME or ~/.hermes.",
+        help=(
+            "Hermes home directory. Defaults to HERMES_HOME, Hermes' own "
+            "resolver, or the platform default."
+        ),
     )
 
     subparsers = parser.add_subparsers(dest="command")

--- a/integrations/hermes/src/memori_hermes/plugin.yaml
+++ b/integrations/hermes/src/memori_hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: memori
-version: 0.1.7
+version: 0.1.8
 description: Structured long-term memory for Hermes Agent using Memori Cloud.
 pip_dependencies:
   - memori>=3.3.3

--- a/integrations/hermes/src/memori_hermes/plugin.yaml
+++ b/integrations/hermes/src/memori_hermes/plugin.yaml
@@ -2,6 +2,6 @@ name: memori
 version: 0.1.7
 description: Structured long-term memory for Hermes Agent using Memori Cloud.
 pip_dependencies:
-  - memori
+  - memori>=3.3.3
 hooks:
   - on_session_end

--- a/integrations/hermes/tests/test_install.py
+++ b/integrations/hermes/tests/test_install.py
@@ -71,6 +71,7 @@ def test_install_plugin_uses_hermes_home_env(
     monkeypatch,
 ) -> None:
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(paths, "_hermes_home_from_hermes", lambda: None)
 
     target = install_plugin()
 
@@ -78,7 +79,20 @@ def test_install_plugin_uses_hermes_home_env(
     assert is_installed()
 
 
-def test_hermes_home_prefers_explicit_env_over_hermes_resolver(
+def test_hermes_home_prefers_explicit_argument_over_resolver(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    explicit_home = tmp_path / "explicit-home"
+    env_home = tmp_path / "env-home"
+    resolver_home = tmp_path / "resolver-home"
+    monkeypatch.setenv("HERMES_HOME", str(env_home))
+    monkeypatch.setattr(paths, "_hermes_home_from_hermes", lambda: resolver_home)
+
+    assert plugin_target_dir(explicit_home) == explicit_home / "plugins" / "memori"
+
+
+def test_hermes_home_prefers_hermes_resolver_over_env(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -87,7 +101,7 @@ def test_hermes_home_prefers_explicit_env_over_hermes_resolver(
     monkeypatch.setenv("HERMES_HOME", str(env_home))
     monkeypatch.setattr(paths, "_hermes_home_from_hermes", lambda: resolver_home)
 
-    assert hermes_home() == env_home
+    assert hermes_home() == resolver_home
 
 
 def test_hermes_home_uses_hermes_resolver_when_available(

--- a/integrations/hermes/tests/test_install.py
+++ b/integrations/hermes/tests/test_install.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+import importlib.util
 import os
 import sys
+import types
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
+import memori_hermes._paths as paths  # noqa: E402
 from memori_hermes.install import (  # noqa: E402
+    hermes_home,
     install_plugin,
     is_installed,
     main,
@@ -21,9 +25,45 @@ def test_install_plugin_copies_provider_to_hermes_plugins(tmp_path: Path) -> Non
     assert target == tmp_path / "plugins" / "memori"
     assert (target / "__init__.py").is_file()
     assert (target / "plugin.yaml").is_file()
+    assert (target / "_paths.py").is_file()
     assert (target / "client.py").is_file()
     assert (target / "tools.py").is_file()
     assert is_installed(hermes_home_path=tmp_path)
+
+
+def test_installed_plugin_loads_with_hermes_style_namespace(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    target = install_plugin(hermes_home_path=tmp_path)
+    module_name = "_hermes_user_memory.memori"
+    parent = types.ModuleType("_hermes_user_memory")
+    parent.__path__ = []  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "_hermes_user_memory", parent)
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        target / "__init__.py",
+        submodule_search_locations=[str(target)],
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+
+    spec.loader.exec_module(module)
+
+    class Collector:
+        provider = None
+
+        def register_memory_provider(self, provider):
+            self.provider = provider
+
+    collector = Collector()
+    module.register(collector)
+
+    assert collector.provider is not None
+    assert collector.provider.name == "memori"
 
 
 def test_install_plugin_uses_hermes_home_env(
@@ -36,6 +76,54 @@ def test_install_plugin_uses_hermes_home_env(
 
     assert target == tmp_path / "plugins" / "memori"
     assert is_installed()
+
+
+def test_hermes_home_prefers_explicit_env_over_hermes_resolver(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    env_home = tmp_path / "env-home"
+    resolver_home = tmp_path / "resolver-home"
+    monkeypatch.setenv("HERMES_HOME", str(env_home))
+    monkeypatch.setattr(paths, "_hermes_home_from_hermes", lambda: resolver_home)
+
+    assert hermes_home() == env_home
+
+
+def test_hermes_home_uses_hermes_resolver_when_available(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    resolver_home = tmp_path / "resolver-home"
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setattr(paths, "_hermes_home_from_hermes", lambda: resolver_home)
+
+    assert hermes_home() == resolver_home
+
+
+def test_hermes_home_uses_windows_platform_default(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    local_appdata = tmp_path / "AppData" / "Local"
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setenv("LOCALAPPDATA", str(local_appdata))
+    monkeypatch.setattr(paths, "_hermes_home_from_hermes", lambda: None)
+    monkeypatch.setattr(paths.sys, "platform", "win32")
+
+    assert hermes_home() == local_appdata / "hermes"
+
+
+def test_hermes_home_uses_posix_platform_default(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(paths, "_hermes_home_from_hermes", lambda: None)
+    monkeypatch.setattr(paths.sys, "platform", "darwin")
+
+    assert hermes_home() == tmp_path / ".hermes"
 
 
 def test_install_plugin_requires_force_for_existing_target(tmp_path: Path) -> None:

--- a/integrations/hermes/tests/test_provider.py
+++ b/integrations/hermes/tests/test_provider.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
+import memori_hermes as provider_module  # noqa: E402
+import memori_hermes._paths as paths  # noqa: E402
 from memori_hermes import MemoriMemoryProvider  # noqa: E402
 
 
@@ -57,6 +59,16 @@ def test_save_config_writes_profile_scoped_memori_json(tmp_path: Path) -> None:
 
     data = json.loads((tmp_path / "memori.json").read_text())
     assert data == {"entityId": "user-1", "projectId": "project-1"}
+
+
+def test_config_path_uses_shared_hermes_home_resolver(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setattr(paths, "_hermes_home_from_hermes", lambda: tmp_path)
+
+    assert provider_module._config_path() == tmp_path / "memori.json"
 
 
 def test_prefetch_does_not_auto_recall() -> None:

--- a/integrations/hermes/tests/test_provider.py
+++ b/integrations/hermes/tests/test_provider.py
@@ -8,7 +8,6 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 import memori_hermes as provider_module  # noqa: E402
 import memori_hermes._paths as paths  # noqa: E402
-from memori_hermes import MemoriMemoryProvider  # noqa: E402
 
 
 class FakeClient:
@@ -50,7 +49,7 @@ class FakeClient:
 
 
 def test_save_config_writes_profile_scoped_memori_json(tmp_path: Path) -> None:
-    provider = MemoriMemoryProvider()
+    provider = provider_module.MemoriMemoryProvider()
 
     provider.save_config(
         {"entity_id": "user-1", "project_id": "project-1"},
@@ -72,7 +71,7 @@ def test_config_path_uses_shared_hermes_home_resolver(
 
 
 def test_prefetch_does_not_auto_recall() -> None:
-    provider = MemoriMemoryProvider(client=FakeClient())
+    provider = provider_module.MemoriMemoryProvider(client=FakeClient())
 
     result = provider.prefetch("database")
 
@@ -81,7 +80,7 @@ def test_prefetch_does_not_auto_recall() -> None:
 
 def test_sync_turn_runs_background_capture() -> None:
     client = FakeClient()
-    provider = MemoriMemoryProvider(client=client)
+    provider = provider_module.MemoriMemoryProvider(client=client)
     provider._session_id = "session-1"
 
     provider.sync_turn("hello", "hi")

--- a/integrations/hermes/tests/test_provider.py
+++ b/integrations/hermes/tests/test_provider.py
@@ -64,7 +64,7 @@ def test_config_path_uses_shared_hermes_home_resolver(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
-    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "env-home"))
     monkeypatch.setattr(paths, "_hermes_home_from_hermes", lambda: tmp_path)
 
     assert provider_module._config_path() == tmp_path / "memori.json"

--- a/integrations/hermes/tests/test_provider.py
+++ b/integrations/hermes/tests/test_provider.py
@@ -8,6 +8,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 import memori_hermes as provider_module  # noqa: E402
 import memori_hermes._paths as paths  # noqa: E402
+from memori_hermes import MemoriMemoryProvider  # noqa: E402
 
 
 class FakeClient:


### PR DESCRIPTION
…ocumentation updates

- Refactored path handling for the Hermes memory plugin to utilize a new `_paths.py` module, centralizing home directory resolution logic.
- Updated `hermes-memori install` command documentation to clarify plugin directory structure and home directory resolution behavior.
- Bumped `memori` dependency version to `>=3.3.3` in plugin configuration files.
- Added tests to validate new path resolution logic and ensure compatibility with existing functionality.

This update improves the robustness of the installation process and enhances user documentation for better clarity.

## What does this PR do?

<!-- Describe the purpose of this change and the problem it solves. -->

## Related issue

<!-- Link the issue this PR addresses, if any. Use "Closes #123", "Fixes #123", or "Related to #123". -->

## Before opening this PR

- [ ] I have checked that there is not already an open PR for this change.
- [ ] I have checked existing issues and discussions for relevant context.
- [ ] I have read the contributing guidelines.

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Test update
- [ ] Refactor or maintenance
- [ ] Performance improvement
- [ ] Build, CI, or release change

## Affected areas

<!-- Select all that apply. -->

- [ ] Python SDK (`memori/`)
- [ ] TypeScript SDK (`memori-ts/`)
- [ ] Rust core or native bindings (`core/`)
- [ ] LLM providers or adapters
- [ ] Storage adapters or drivers
- [ ] Memory augmentation or recall
- [ ] Examples or integrations
- [ ] Documentation
- [ ] CI, packaging, or tooling

## How was this tested?

<!-- List the commands you ran and any relevant manual checks. If not tested, explain why. -->

- [ ] `uv run pytest`
- [ ] `uv run ruff check .`
- [ ] `uv run ruff format --check .`
- [ ] `npm test` from `memori-ts/`
- [ ] `npm run lint` from `memori-ts/`
- [ ] Integration tests
- [ ] Manual testing

## Checklist

- [ ] I have kept this change focused and consistent with the existing architecture.
- [ ] I have added or updated tests where appropriate.
- [ ] I have updated documentation or examples for user-facing changes.
- [ ] This PR does not require live API keys for unit tests.
- [ ] This PR does not include generated artifacts, local databases, or cache files.
- [ ] I have called out any breaking changes, migration steps, or compatibility concerns below.

## Notes for reviewers

<!-- Add screenshots, API examples, migration notes, risks, or follow-up work that reviewers should know about. -->
