### PR TITLE
Enhance API post method to support custom timeout

### DIFF
--- a/memori/_network.py
+++ b/memori/_network.py
@@ -205,13 +205,16 @@ class Api:
     async def patch_async(self, route, json=None):
         return await self.__request_async("PATCH", route, json=json)
 
-    def post(self, route, json=None, status_code: bool = False):
+    def post(self, route, json=None, status_code: bool = False, timeout: int = None):
+        if timeout is None:
+            timeout = self.config.request_secs_timeout
+
         logger.debug("POST request to %s", route)
         r = self.__session().post(
             self.url(route),
             headers=self.headers(),
             json=json,
-            timeout=self.config.request_secs_timeout,
+            timeout=timeout,
         )
         logger.debug("POST response - status: %d", r.status_code)
 

--- a/memori/_network.py
+++ b/memori/_network.py
@@ -205,7 +205,9 @@ class Api:
     async def patch_async(self, route, json=None):
         return await self.__request_async("PATCH", route, json=json)
 
-    def post(self, route, json=None, status_code: bool = False, timeout: int = None):
+    def post(
+        self, route, json=None, status_code: bool = False, timeout: int | None = None
+    ):
         if timeout is None:
             timeout = self.config.request_secs_timeout
 

--- a/memori/storage/cockroachdb/_cluster_manager.py
+++ b/memori/storage/cockroachdb/_cluster_manager.py
@@ -120,6 +120,7 @@ class ClusterManager:
             finalized = Api(Config()).post(
                 f"cockroachdb/cluster/finalize/{started['cluster']['uuid']}",
                 json={"cluster": {"id": started["cluster"]["id"]}},
+                timeout=60,
             )
             if finalized["status"] == 1:
                 break

--- a/tests/storage/cockroachdb/test_storage_cockroachdb_cluster_manager.py
+++ b/tests/storage/cockroachdb/test_storage_cockroachdb_cluster_manager.py
@@ -1,0 +1,52 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+from memori._config import Config
+from memori.storage.cockroachdb._cluster_manager import ClusterManager
+
+
+def test_start_finalize_post_uses_extended_timeout():
+    config = Config()
+    cli = MagicMock()
+    manager = ClusterManager(config)
+
+    cluster_uuid = "test-cluster-uuid"
+    started = {"cluster": {"uuid": cluster_uuid, "id": 123}}
+    finalized = {
+        "status": 1,
+        "connection": {"string": "postgresql://user:pass@host/db"},
+        "claim": {"url": "https://claim.example.com"},
+    }
+
+    mock_api = MagicMock()
+    mock_api.post.side_effect = [started, finalized]
+    mock_psycopg = MagicMock()
+
+    with (
+        patch.object(manager, "cluster_is_started", return_value=False),
+        patch("builtins.input", return_value="Y"),
+        patch(
+            "memori.storage.cockroachdb._cluster_manager.Api",
+            return_value=mock_api,
+        ),
+        patch("memori.storage.cockroachdb._cluster_manager.time.sleep"),
+        patch("memori.storage.cockroachdb._cluster_manager.Manager") as mock_manager,
+        patch("memori.storage.cockroachdb._cluster_manager.Builder") as mock_builder,
+        patch.dict(sys.modules, {"psycopg": mock_psycopg}),
+        patch.object(manager.files, "write_id"),
+    ):
+        mock_manager.return_value.start.return_value = MagicMock()
+        manager.start(cli)
+
+    assert mock_api.post.call_count == 2
+
+    start_call = mock_api.post.call_args_list[0]
+    assert start_call.args == ("cockroachdb/cluster/start",)
+    assert "timeout" not in start_call.kwargs
+
+    finalize_call = mock_api.post.call_args_list[1]
+    assert finalize_call.args == (f"cockroachdb/cluster/finalize/{cluster_uuid}",)
+    assert finalize_call.kwargs["json"] == {"cluster": {"id": 123}}
+    assert finalize_call.kwargs["timeout"] == 60
+
+    mock_builder.return_value.disable_banner.return_value.execute.assert_called_once()

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -160,6 +160,39 @@ class TestApiPost:
         with pytest.raises(requests.HTTPError):
             api.post("test/endpoint")
 
+    def test_post_uses_configured_timeout_by_default(self, api, mocker):
+        custom_timeout = 42
+        api.config.request_secs_timeout = custom_timeout
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"result": "success"}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_session = MagicMock()
+        mock_session.post.return_value = mock_response
+        mocker.patch.object(api, "_Api__session", return_value=mock_session)
+
+        api.post("test/endpoint")
+
+        _, kwargs = mock_session.post.call_args
+        assert kwargs["timeout"] == custom_timeout
+
+    def test_post_uses_custom_timeout_when_provided(self, api, mocker):
+        api.config.request_secs_timeout = 5
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"result": "success"}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_session = MagicMock()
+        mock_session.post.return_value = mock_response
+        mocker.patch.object(api, "_Api__session", return_value=mock_session)
+
+        api.post("test/endpoint", timeout=60)
+
+        _, kwargs = mock_session.post.call_args
+        assert kwargs["timeout"] == 60
+
 
 class TestApiPostAsync:
     @pytest.mark.asyncio


### PR DESCRIPTION
- Updated the `post` method in the `Api` class to accept an optional `timeout` parameter, defaulting to the configured request timeout if not provided.
- Adjusted the `ClusterManager` to utilize the new timeout feature when finalizing cluster operations.
- Added tests to verify that the configured timeout is used by default and that custom timeouts are correctly applied when specified.

## What does this PR do?

<!-- Describe the purpose of this change and the problem it solves. -->

## Related issue

<!-- Link the issue this PR addresses, if any. Use "Closes #123", "Fixes #123", or "Related to #123". -->

## Before opening this PR

- [ ] I have checked that there is not already an open PR for this change.
- [ ] I have checked existing issues and discussions for relevant context.
- [ ] I have read the contributing guidelines.

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Test update
- [ ] Refactor or maintenance
- [ ] Performance improvement
- [ ] Build, CI, or release change

## Affected areas

<!-- Select all that apply. -->

- [ ] Python SDK (`memori/`)
- [ ] TypeScript SDK (`memori-ts/`)
- [ ] Rust core or native bindings (`core/`)
- [ ] LLM providers or adapters
- [ ] Storage adapters or drivers
- [ ] Memory augmentation or recall
- [ ] Examples or integrations
- [ ] Documentation
- [ ] CI, packaging, or tooling

## How was this tested?

<!-- List the commands you ran and any relevant manual checks. If not tested, explain why. -->

- [ ] `uv run pytest`
- [ ] `uv run ruff check .`
- [ ] `uv run ruff format --check .`
- [ ] `npm test` from `memori-ts/`
- [ ] `npm run lint` from `memori-ts/`
- [ ] Integration tests
- [ ] Manual testing

## Checklist

- [ ] I have kept this change focused and consistent with the existing architecture.
- [ ] I have added or updated tests where appropriate.
- [ ] I have updated documentation or examples for user-facing changes.
- [ ] This PR does not require live API keys for unit tests.
- [ ] This PR does not include generated artifacts, local databases, or cache files.
- [ ] I have called out any breaking changes, migration steps, or compatibility concerns below.

## Notes for reviewers

<!-- Add screenshots, API examples, migration notes, risks, or follow-up work that reviewers should know about. -->
