### PR TITLE
Revise docs: roadmap line, added an enterprise agent trace example

### DIFF
--- a/docs/memori-byodb/getting-started/python-quickstart.mdx
+++ b/docs/memori-byodb/getting-started/python-quickstart.mdx
@@ -5,7 +5,7 @@ description: Get started with Memori BYODB in under 3 minutes using SQLite and O
 
 # Python SDK Quickstart
 
-Get started with Memori in under 3 minutes. Since Memori BYODB is open source, you bring your own database — and for this quick start, we will use SQLite so there is nothing extra to install.
+Get started with Memori in minutes. Since Memori BYODB is open source, you bring your own database and for this quick start, we will use SQLite so there is nothing extra to install.
 
 <Note>
   Want a zero-setup option? Try Memori Cloud at

--- a/docs/memori-byodb/getting-started/use-cases.mdx
+++ b/docs/memori-byodb/getting-started/use-cases.mdx
@@ -30,7 +30,7 @@ from sqlalchemy.orm import sessionmaker
 from memori import Memori
 from openai import OpenAI
 
-engine = create_engine("sqlite:///memori.db")
+engine = create_engine("cockroachdb+psycopg2://user:password@localhost:26257/memori_db")
 SessionLocal = sessionmaker(bind=engine)
 
 client = OpenAI()
@@ -71,7 +71,7 @@ from sqlalchemy.orm import sessionmaker
 from memori import Memori
 from anthropic import Anthropic
 
-engine = create_engine("sqlite:///memori.db")
+engine = create_engine("cockroachdb+psycopg2://user:password@localhost:26257/memori_db")
 SessionLocal = sessionmaker(bind=engine)
 
 client = Anthropic()
@@ -113,7 +113,7 @@ from sqlalchemy.orm import sessionmaker
 from memori import Memori
 from openai import OpenAI
 
-engine = create_engine("sqlite:///memori.db")
+engine = create_engine("cockroachdb+psycopg2://user:password@localhost:26257/memori_db")
 SessionLocal = sessionmaker(bind=engine)
 
 client = OpenAI()
@@ -139,4 +139,118 @@ mem.attribution(
 )
 # Memori shares context across agents
 # for the same entity
+```
+
+## Enterprise IT Operations — Incident Response
+
+Large enterprises run hundreds of services across complex infrastructure. When incidents strike, response time is critical. Memori captures every tool call, diagnostic decision, and resolution outcome as structured trace memory — so agents accumulate institutional knowledge across incidents and come back faster each time.
+
+**Benefits:**
+
+- Recall past incidents with similar error patterns and known resolutions
+- Build a persistent knowledge base of system behavior across thousands of incidents
+- Reduce mean time to resolution by surfacing what worked before
+- Audit the full decision trail: which tools ran, what they returned, and what action was taken
+- Route incident context across specialized agents — triage, escalation, and remediation
+
+```python
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from memori import Memori
+from openai import OpenAI
+
+engine = create_engine("cockroachdb+psycopg2://user:password@localhost:26257/memori_db")
+SessionLocal = sessionmaker(bind=engine)
+
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+mem = Memori(conn=SessionLocal).llm.register(client)
+
+# Each service gets its own memory space; the agent is the process
+mem.attribution(
+    entity_id="payment-service-prod",
+    process_id="incident_response_agent"
+)
+
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "query_logs",
+            "description": "Query application logs for a time range and filter",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "service": {"type": "string"},
+                    "time_range": {"type": "string"},
+                    "filter": {"type": "string"}
+                },
+                "required": ["service", "time_range"]
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_metrics",
+            "description": "Retrieve service metrics from the monitoring system",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "service": {"type": "string"},
+                    "metric": {"type": "string"}
+                },
+                "required": ["service", "metric"]
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "restart_pod",
+            "description": "Restart a service pod in the specified region",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "service": {"type": "string"},
+                    "region": {"type": "string"}
+                },
+                "required": ["service", "region"]
+            }
+        }
+    }
+]
+
+# Memori intercepts this call — tool calls, results, and decisions
+# are captured as trace events and converted into structured memory
+response = client.chat.completions.create(
+    model="gpt-4.1-mini",
+    messages=[
+        {
+            "role": "system",
+            "content": "You are an enterprise IT operations agent. Diagnose and resolve infrastructure incidents."
+        },
+        {
+            "role": "user",
+            "content": (
+                "P1 Alert: payment-service-prod returning 503 errors. "
+                "Error rate 42%, p99 latency 8.2s. Started 14 minutes ago. "
+                "Diagnose and resolve."
+            )
+        }
+    ],
+    tools=tools
+)
+
+# After resolution, Memori has stored:
+# - The alert conditions that triggered the incident
+# - Every tool call made and what it returned
+# - The diagnostic path and decisions taken
+# - The resolution action and outcome
+#
+# Next incident: the agent automatically recalls
+# "Last time payment-service-prod had 503s with elevated p99 latency,
+#  logs showed DB connection pool exhaustion — resolved by restarting
+#  the us-east-1 pod. Resolution time: 6 minutes."
+mem.augmentation.wait()
 ```

--- a/docs/memori-byodb/index.mdx
+++ b/docs/memori-byodb/index.mdx
@@ -52,7 +52,7 @@ Get started with a database connection and your favorite LLM:
 - **Semantic recall** — Queries like “what does this user prefer?” pull the right memories automatically.
 - **Dashboard** — Use [app.memorilabs.ai](https://app.memorilabs.ai) for API keys, usage, and (with Memori Cloud) the Graph Explorer and Playground.
 - **Your data, your rules** — Store everything in your DB; compliance, backups, and custom analytics stay under your control.
-- **Roadmap** — Knowledge-graph APIs, configurable decay, and richer dashboarding are on the way.
+- **Roadmap** — Augmentation pipeline improvements for more consistent entity, project, and memory creation. Better visibility into what agents remember.
 
 ```python
 import os

--- a/docs/memori-cloud/getting-started/use-cases.mdx
+++ b/docs/memori-cloud/getting-started/use-cases.mdx
@@ -200,7 +200,205 @@ mem.attribution('project_alpha', 'analysis_agent');
 
 </CodeGroup>
 
-<Note>
-  For runnable versions of these examples and more, see the [examples
-  folder](https://github.com/MemoriLabs/Memori/tree/main/examples) on GitHub.
-</Note>
+## Enterprise IT Operations — Incident Response
+
+Large enterprises run hundreds of services across complex infrastructure. When incidents strike, response time is critical. Memori captures every tool call, diagnostic decision, and resolution outcome as structured trace memory — so agents accumulate institutional knowledge across incidents and come back faster each time.
+
+**Benefits:**
+
+- Recall past incidents with similar error patterns and known resolutions
+- Build a persistent knowledge base of system behavior across thousands of incidents
+- Reduce mean time to resolution by surfacing what worked before
+- Audit the full decision trail: which tools ran, what they returned, and what action was taken
+- Route incident context across specialized agents — triage, escalation, and remediation
+
+<CodeGroup title="Enterprise IT Operations">
+
+```python {{ title: 'Python' }}
+import os
+from memori import Memori
+from openai import OpenAI
+
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+mem = Memori().llm.register(client)
+
+# Each service gets its own memory space; the agent is the process
+mem.attribution(
+    entity_id="payment-service-prod",
+    process_id="incident_response_agent"
+)
+
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "query_logs",
+            "description": "Query application logs for a time range and filter",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "service": {"type": "string"},
+                    "time_range": {"type": "string"},
+                    "filter": {"type": "string"}
+                },
+                "required": ["service", "time_range"]
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_metrics",
+            "description": "Retrieve service metrics from the monitoring system",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "service": {"type": "string"},
+                    "metric": {"type": "string"}
+                },
+                "required": ["service", "metric"]
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "restart_pod",
+            "description": "Restart a service pod in the specified region",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "service": {"type": "string"},
+                    "region": {"type": "string"}
+                },
+                "required": ["service", "region"]
+            }
+        }
+    }
+]
+
+# Memori intercepts this call — tool calls, results, and decisions
+# are captured as trace events and converted into structured memory
+response = client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[
+        {
+            "role": "system",
+            "content": "You are an enterprise IT operations agent. Diagnose and resolve infrastructure incidents."
+        },
+        {
+            "role": "user",
+            "content": (
+                "P1 Alert: payment-service-prod returning 503 errors. "
+                "Error rate 42%, p99 latency 8.2s. Started 14 minutes ago. "
+                "Diagnose and resolve."
+            )
+        }
+    ],
+    tools=tools
+)
+
+# After resolution, Memori has stored:
+# - The alert conditions that triggered the incident
+# - Every tool call made and what it returned
+# - The diagnostic path and decisions taken
+# - The resolution action and outcome
+#
+# Next incident: the agent automatically recalls
+# "Last time payment-service-prod had 503s with elevated p99 latency,
+#  logs showed DB connection pool exhaustion — resolved by restarting
+#  the us-east-1 pod. Resolution time: 6 minutes."
+```
+
+```typescript {{ title: 'TypeScript' }}
+import OpenAI from 'openai';
+import { Memori } from '@memorilabs/memori';
+
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const mem = new Memori().llm.register(client);
+
+// Each service gets its own memory space; the agent is the process
+mem.attribution('payment-service-prod', 'incident_response_agent');
+
+const tools: OpenAI.Chat.Completions.ChatCompletionTool[] = [
+  {
+    type: 'function',
+    function: {
+      name: 'query_logs',
+      description: 'Query application logs for a time range and filter',
+      parameters: {
+        type: 'object',
+        properties: {
+          service: { type: 'string' },
+          time_range: { type: 'string' },
+          filter: { type: 'string' },
+        },
+        required: ['service', 'time_range'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'get_metrics',
+      description: 'Retrieve service metrics from the monitoring system',
+      parameters: {
+        type: 'object',
+        properties: {
+          service: { type: 'string' },
+          metric: { type: 'string' },
+        },
+        required: ['service', 'metric'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'restart_pod',
+      description: 'Restart a service pod in the specified region',
+      parameters: {
+        type: 'object',
+        properties: {
+          service: { type: 'string' },
+          region: { type: 'string' },
+        },
+        required: ['service', 'region'],
+      },
+    },
+  },
+];
+
+// Memori intercepts this call — tool calls, results, and decisions
+// are captured as trace events and converted into structured memory
+const response = await client.chat.completions.create({
+  model: 'gpt-4o-mini',
+  messages: [
+    {
+      role: 'system',
+      content: 'You are an enterprise IT operations agent. Diagnose and resolve infrastructure incidents.',
+    },
+    {
+      role: 'user',
+      content:
+        'P1 Alert: payment-service-prod returning 503 errors. ' +
+        'Error rate 42%, p99 latency 8.2s. Started 14 minutes ago. ' +
+        'Diagnose and resolve.',
+    },
+  ],
+  tools,
+});
+
+// After resolution, Memori has stored:
+// - The alert conditions that triggered the incident
+// - Every tool call made and what it returned
+// - The diagnostic path and decisions taken
+// - The resolution action and outcome
+//
+// Next incident: the agent automatically recalls
+// "Last time payment-service-prod had 503s with elevated p99 latency,
+//  logs showed DB connection pool exhaustion — resolved by restarting
+//  the us-east-1 pod. Resolution time: 6 minutes."
+```
+
+</CodeGroup>


### PR DESCRIPTION
- Revised roadmap bullet in memori-byodb index to focus on augmentation pipeline improvements and agent memory visibility
- Added Enterprise IT Ops incident response use case to both memori-byodb and memori-cloud use-cases pages, showing agent trace memory with OpenAI tool calls (query_logs, get_metrics, restart_pod)
- Switched all memori-byodb use-case examples from SQLite to CockroachDB
- Fixed cloud use-case example: model corrected to gpt-4o-mini, removed augmentation.wait() (not applicable in cloud)