### PR TITLE
chore: update pyo3 and related packages to version 0.29.0 in Cargo.lo…

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -2212,9 +2212,9 @@ checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "pyo3"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "libc",
  "once_cell",
@@ -2226,18 +2226,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2245,9 +2245,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2257,13 +2257,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -55,7 +55,7 @@ rust-version = "1.86"
 [workspace.dependencies]
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
-pyo3 = "0.28"
+pyo3 = "0.29"
 napi = "3"
 napi-derive = "3"
 napi-build = "2"


### PR DESCRIPTION
…ck and Cargo.toml

## What does this PR do?

<!-- Describe the purpose of this change and the problem it solves. -->

## Related issue

<!-- Link the issue this PR addresses, if any. Use "Closes #123", "Fixes #123", or "Related to #123". -->

## Before opening this PR

- [ ] I have checked that there is not already an open PR for this change.
- [ ] I have checked existing issues and discussions for relevant context.
- [ ] I have read the contributing guidelines.

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Test update
- [ ] Refactor or maintenance
- [ ] Performance improvement
- [ ] Build, CI, or release change

## Affected areas

<!-- Select all that apply. -->

- [ ] Python SDK (`memori/`)
- [ ] TypeScript SDK (`memori-ts/`)
- [ ] Rust core or native bindings (`core/`)
- [ ] LLM providers or adapters
- [ ] Storage adapters or drivers
- [ ] Memory augmentation or recall
- [ ] Examples or integrations
- [ ] Documentation
- [ ] CI, packaging, or tooling

## How was this tested?

<!-- List the commands you ran and any relevant manual checks. If not tested, explain why. -->

- [ ] `uv run pytest`
- [ ] `uv run ruff check .`
- [ ] `uv run ruff format --check .`
- [ ] `npm test` from `memori-ts/`
- [ ] `npm run lint` from `memori-ts/`
- [ ] Integration tests
- [ ] Manual testing

## Checklist

- [ ] I have kept this change focused and consistent with the existing architecture.
- [ ] I have added or updated tests where appropriate.
- [ ] I have updated documentation or examples for user-facing changes.
- [ ] This PR does not require live API keys for unit tests.
- [ ] This PR does not include generated artifacts, local databases, or cache files.
- [ ] I have called out any breaking changes, migration steps, or compatibility concerns below.

## Notes for reviewers

<!-- Add screenshots, API examples, migration notes, risks, or follow-up work that reviewers should know about. -->
