### PR TITLE
docs: clarify manual installation for hermes-memori

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ mkdir -p "$HERMES_HOME"
 echo "MEMORI_API_KEY=YOUR_MEMORI_API_KEY" >> "$HERMES_HOME/.env"
 echo "MEMORI_ENTITY_ID=your-app-user-id" >> "$HERMES_HOME/.env"
 ```
+> [!NOTE]
+> Due to recent Hermes plugin architecture and bundling policies, third-party memory providers cannot be embedded natively. `hermes-memori` must remain a separately installed provider via the manual steps above.
 
 `MEMORI_PROJECT_ID` is optional; when omitted, the provider uses Hermes' active project context for scoping.
 


### PR DESCRIPTION
Added note about Hermes plugin architecture and third-party memory providers.

## What does this PR do?

Adds an official GitHub Markdown alert note to the Hermes Agent section in the README.md file. This clarifies that the `hermes-memori` provider requires a manual installation step due to Hermes' current plugin architecture and embedding policies. 

## Related issue

Related to #610

## Before opening this PR

- [x] I have checked that there is not already an open PR for this change.
- [x] I have checked existing issues and discussions for relevant context.
- [x] I have read the contributing guidelines.

## Type of change

- [x] Documentation update

## Affected areas

- [x] Documentation

## How was this tested?

Manual verification of the markdown file layout.

## Checklist

- [x] I have kept this change focused and consistent with the existing architecture.
- [x] I have updated documentation or examples for user-facing changes.
- [x] This PR does not require live API keys for unit tests.
- [x] This PR does not include generated artifacts, local databases, or cache files.

## Notes for reviewers

This directly resolves user confusion regarding native bundling vs manual installation requirements brought up in issue #610.
