### PR TITLE
fix(memory): reject empty entity IDs during deletion

### DIFF
--- a/memori/__init__.py
+++ b/memori/__init__.py
@@ -258,6 +258,8 @@ class Memori:
 
         if entity_id is not None and not isinstance(entity_id, str):
             raise TypeError("entity_id must be a string or None")
+        if entity_id is not None and not entity_id:
+            raise ValueError("entity_id cannot be empty")
         if entity_id is not None and len(entity_id) > 100:
             raise RuntimeError("entity_id cannot be greater than 100 characters")
 

--- a/memori/memory/recall.py
+++ b/memori/memory/recall.py
@@ -195,7 +195,11 @@ class Recall:
             logger.debug("Entity memory deletion aborted - storage not configured")
             return
 
-        resolved_external_id = entity_external_id or self.config.entity_id
+        resolved_external_id = (
+            entity_external_id
+            if entity_external_id is not None
+            else self.config.entity_id
+        )
         if resolved_external_id is None:
             logger.debug("Entity memory deletion aborted - no entity_id configured")
             return

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -399,3 +399,18 @@ def test_delete_entity_memories_rejected_for_cockroach_connection_string(
 
     assert mem.config.byodb is False
     assert str(e.value) == "delete_entity_memories is only available in BYODB mode"
+
+
+def test_delete_entity_memories_rejects_empty_entity_id(mocker):
+    mock_conn = mocker.Mock(spec=["cursor", "commit", "rollback"])
+    mock_conn.__module__ = "psycopg"
+    type(mock_conn).__module__ = "psycopg"
+    mock_cursor = mocker.MagicMock()
+    mock_conn.cursor = mocker.MagicMock(return_value=mock_cursor)
+
+    mem = Memori(conn=lambda: mock_conn)
+
+    with pytest.raises(ValueError) as e:
+        mem.delete_entity_memories("")
+
+    assert str(e.value) == "entity_id cannot be empty"


### PR DESCRIPTION
## What does this PR do?

Fixes a data-loss edge case in `delete_entity_memories()` where passing an empty string (`""`) could incorrectly fall back to the configured default entity due to Python truthiness.

## Related issue

N/A

## Before opening this PR

- [x] I have checked that there is not already an open PR for this change.
- [x] I have checked existing issues and discussions for relevant context.
- [x] I have read the contributing guidelines.

## Affected components

- [x] Python SDK (`memori/`)
- [x] Memory augmentation or recall

## How was this tested?

- [x] `uv run pytest`
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`

## Checklist

- [x] I have kept this change focused and consistent with the existing architecture.
- [x] I have added or updated tests where appropriate.
- [ ] I have updated documentation or examples for user-facing changes.
- [x] This PR does not require live API keys for unit tests.
- [x] This PR does not include generated artifacts, local databases, or cache files.
- [x] I have called out any breaking changes, migration steps, or compatibility concerns below.

## Notes for reviewers

This PR adds an explicit validation for empty entity IDs at the public API boundary and replaces the internal truthiness fallback with an explicit `is not None` check. A regression test has been added to prevent the data-loss scenario from recurring.