### PR TITLE
Add MiniMax platform detection for OpenAI- and Anthropic-compatible endpoints

### DIFF
--- a/docs/memori-cloud/llm/minimax.mdx
+++ b/docs/memori-cloud/llm/minimax.mdx
@@ -1,0 +1,126 @@
+---
+title: MiniMax
+description: Using Memori with MiniMax models via the OpenAI-compatible and Anthropic-compatible APIs on Memori Cloud.
+---
+
+# MiniMax
+
+MiniMax exposes both an OpenAI-compatible API and an Anthropic-compatible API. Use the `openai` or `anthropic` Python package with a MiniMax `base_url` — no special adapter needed. Memori identifies the platform from the base URL for both the global and mainland-China endpoints.
+
+| Region | OpenAI-compatible base URL    | Anthropic-compatible base URL        |
+| ------ | ----------------------------- | ------------------------------------ |
+| Global | `https://api.minimax.io/v1`   | `https://api.minimax.io/anthropic`   |
+| China  | `https://api.minimaxi.com/v1` | `https://api.minimaxi.com/anthropic` |
+
+Current models: `MiniMax-M3` (1,000,000 token context) and `MiniMax-M2.7` (204,800 token context).
+
+<Note>
+  TypeScript support for MiniMax is coming soon.
+</Note>
+
+## OpenAI-Compatible API
+
+<CodeGroup title="MiniMax OpenAI-Compatible Integration">
+
+```python {{ title: 'Sync' }}
+import os
+from memori import Memori
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://api.minimax.io/v1",
+    api_key=os.getenv("MINIMAX_API_KEY"),
+)
+
+mem = Memori().llm.register(client)
+mem.attribution(entity_id="user_123", process_id="minimax_assistant")
+
+response = client.chat.completions.create(
+    model="MiniMax-M3",
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+print(response.choices[0].message.content)
+```
+
+```python {{ title: 'Async' }}
+import os, asyncio
+from memori import Memori
+from openai import AsyncOpenAI
+
+client = AsyncOpenAI(
+    base_url="https://api.minimax.io/v1",
+    api_key=os.getenv("MINIMAX_API_KEY"),
+)
+
+mem = Memori().llm.register(client)
+mem.attribution(entity_id="user_123", process_id="minimax_assistant")
+
+async def main():
+    response = await client.chat.completions.create(
+        model="MiniMax-M2.7",
+        messages=[{"role": "user", "content": "Hello!"}]
+    )
+    print(response.choices[0].message.content)
+
+asyncio.run(main())
+```
+
+```python {{ title: 'Streaming' }}
+import os
+from memori import Memori
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://api.minimax.io/v1",
+    api_key=os.getenv("MINIMAX_API_KEY"),
+)
+
+mem = Memori().llm.register(client)
+mem.attribution(entity_id="user_123", process_id="minimax_assistant")
+
+stream = client.chat.completions.create(
+    model="MiniMax-M3",
+    messages=[{"role": "user", "content": "Hello!"}],
+    stream=True
+)
+for chunk in stream:
+    if chunk.choices[0].delta.content:
+        print(chunk.choices[0].delta.content, end="")
+```
+
+</CodeGroup>
+
+To use the mainland-China endpoint, set `base_url="https://api.minimaxi.com/v1"`.
+
+## Anthropic-Compatible API
+
+```python
+import os
+from memori import Memori
+from anthropic import Anthropic
+
+client = Anthropic(
+    base_url="https://api.minimax.io/anthropic",
+    api_key=os.getenv("MINIMAX_API_KEY"),
+)
+
+mem = Memori().llm.register(client)
+mem.attribution(entity_id="user_123", process_id="minimax_assistant")
+
+response = client.messages.create(
+    model="MiniMax-M3",
+    max_tokens=256,
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+print(response.content[0].text)
+```
+
+To use the mainland-China endpoint, set `base_url="https://api.minimaxi.com/anthropic"`.
+
+## Supported Modes
+
+| Mode         | Method                                   |
+| ------------ | ---------------------------------------- |
+| **Sync**     | `client.chat.completions.create()`       |
+| **Async**    | `await client.chat.completions.create()` |
+| **Streamed** | `stream=True` parameter                  |

--- a/docs/memori-cloud/llm/overview.mdx
+++ b/docs/memori-cloud/llm/overview.mdx
@@ -18,6 +18,7 @@ Memori Cloud works with all major LLM providers and frameworks. Register any sup
 | **[AWS Bedrock](/docs/memori-cloud/llm/aws-bedrock)** | LangChain adapter  | `pip install memori langchain-aws`    | Coming soon                                         |
 | **[DeepSeek](/docs/memori-cloud/llm/deepseek)**       | OpenAI-compatible  | `pip install memori openai`           | Coming soon                                         |
 | **[LangChain](/docs/memori-cloud/llm/langchain)**     | Framework support  | `pip install memori langchain-openai` | Coming soon                                         |
+| **[MiniMax](/docs/memori-cloud/llm/minimax)**         | OpenAI-compatible  | `pip install memori openai`           | Coming soon                                         |
 | **[Nebius AI Studio](/docs/memori-cloud/llm/nebius)** | OpenAI-compatible  | `pip install memori openai`           | Coming soon                                         |
 | **[Pydantic AI](/docs/memori-cloud/llm/pydantic-ai)** | Framework support  | `pip install memori pydantic-ai`      | Coming soon                                         |
 | **[xAI Grok](/docs/memori-cloud/llm/xai-grok)**       | OpenAI-compatible  | `pip install memori openai`           | Coming soon                                         |
@@ -43,7 +44,7 @@ print(result.output)
 
 ## OpenAI-Compatible Providers
 
-Any provider with an OpenAI-compatible API works by setting a custom `base_url`. Dedicated guides: [xAI Grok](/docs/memori-cloud/llm/xai-grok), [Nebius AI Studio](/docs/memori-cloud/llm/nebius), [DeepSeek](/docs/memori-cloud/llm/deepseek). Same pattern works for Azure OpenAI, NVIDIA NIM, and others.
+Any provider with an OpenAI-compatible API works by setting a custom `base_url`. Dedicated guides: [xAI Grok](/docs/memori-cloud/llm/xai-grok), [Nebius AI Studio](/docs/memori-cloud/llm/nebius), [DeepSeek](/docs/memori-cloud/llm/deepseek), [MiniMax](/docs/memori-cloud/llm/minimax). Same pattern works for Azure OpenAI, NVIDIA NIM, and others.
 
 ```python
 import os

--- a/memori/llm/clients/direct.py
+++ b/memori/llm/clients/direct.py
@@ -28,6 +28,10 @@ class Anthropic(BaseClient):
             raise RuntimeError("client provided is not instance of Anthropic")
 
         if not hasattr(client, "_memori_installed"):
+            platform = _detect_platform(client)
+            if platform:
+                self.config.platform.provider = platform
+
             client.beta._messages_create = client.beta.messages.create
             client._messages_create = client.messages.create
 
@@ -149,6 +153,8 @@ def _detect_platform(client):
             return "deepseek"
         if "nvidia" in base_url:
             return "nvidia_nim"
+        if "minimax" in base_url:
+            return "minimax"
     return None
 
 

--- a/tests/llm/test_llm_provider_sdk_version.py
+++ b/tests/llm/test_llm_provider_sdk_version.py
@@ -250,6 +250,55 @@ def test_deepseek_platform(openai_client, mocker):
     assert openai_client.config.llm.provider_sdk_version == "2.8.1"
 
 
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://api.minimax.io/v1",
+        "https://api.minimaxi.com/v1",
+    ],
+)
+def test_minimax_openai_platform(openai_client, mocker, base_url):
+    """MiniMax is detected from the OpenAI-compatible base URL on both regions."""
+    mock_client = mocker.MagicMock()
+    mock_client._version = "2.8.1"
+    mock_client.base_url = base_url
+    mock_client.chat.completions.create = mocker.MagicMock()
+    mock_client.beta.chat.completions.parse = mocker.MagicMock()
+    del mock_client._memori_installed
+
+    mocker.patch("asyncio.get_running_loop", side_effect=RuntimeError)
+
+    openai_client.register(mock_client)
+
+    assert openai_client.config.platform.provider == "minimax"
+    assert openai_client.config.llm.provider_sdk_version == "2.8.1"
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://api.minimax.io/anthropic",
+        "https://api.minimaxi.com/anthropic",
+    ],
+)
+def test_minimax_anthropic_platform(anthropic_client, mocker, base_url):
+    """MiniMax is detected from the Anthropic-compatible base URL on both regions."""
+    mock_client = mocker.MagicMock()
+    mock_client.base_url = base_url
+    mock_client.messages.create = mocker.MagicMock()
+    mock_client.beta.messages.create = mocker.MagicMock()
+    del mock_client._memori_installed
+
+    mock_anthropic_module = mocker.MagicMock()
+    mock_anthropic_module.__version__ = "0.75.0"
+    mocker.patch.dict("sys.modules", {"anthropic": mock_anthropic_module})
+    mocker.patch("asyncio.get_running_loop", side_effect=RuntimeError)
+
+    anthropic_client.register(mock_client)
+
+    assert anthropic_client.config.platform.provider == "minimax"
+
+
 def test_provider_sdk_version_separate_from_model_version(openai_client, mocker):
     """Test that provider_sdk_version is separate from model version (llm.version)."""
     mock_client = mocker.MagicMock()


### PR DESCRIPTION
Reason: The OpenAI-compatible client wrapper detects several base URLs but does not identify MiniMax, and the Anthropic-compatible endpoint is not covered.

## What this does

- Adds MiniMax platform detection to `_detect_platform()` in `memori/llm/clients/direct.py`. A client whose `base_url` contains `minimax` is now identified as the `minimax` platform, covering both the global endpoint (`https://api.minimax.io`) and the mainland-China endpoint (`https://api.minimaxi.com`).
- Extends the `Anthropic` client's `register()` to run the same base-URL platform detection, so the Anthropic-compatible endpoint (`https://api.minimax.io/anthropic`, `https://api.minimaxi.com/anthropic`) is now identified as well — previously platform detection only ran for OpenAI-compatible clients.
- Adds a MiniMax integration guide under `docs/memori-cloud/llm/minimax.mdx` and lists it in the provider overview. The guide documents both the OpenAI-compatible and Anthropic-compatible endpoints for the global and China regions and uses the current `MiniMax-M3` and `MiniMax-M2.7` models.

## Tests

- Adds parametrized unit tests in `tests/llm/test_llm_provider_sdk_version.py` asserting that the `minimax` platform is detected from the OpenAI-compatible base URL and from the Anthropic-compatible base URL, for both the global and China regions.

## Checks

- `ruff format --check` on the changed Python files — passed.
- `ruff check` on the changed Python files — passed.
- `python -m pytest tests/llm/test_llm_provider_sdk_version.py` — 17 passed.
