### PR TITLE
fix: preserve multipart Responses queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `query` raises `ValueError`, matching the existing `limit` validation and
   failing fast instead of issuing an empty recall against the database/LLM path.
 
+### Fixed
+
+- OpenAI Responses recall queries now include every `input_text` block from a
+  multipart user message instead of silently dropping all but the first block.
+
 ## [3.3.6] - 2026-05-27
 
 ### Added

--- a/memori/llm/helpers/query_extraction.py
+++ b/memori/llm/helpers/query_extraction.py
@@ -64,17 +64,20 @@ def extract_user_query(kwargs: dict) -> str:
                     if isinstance(content, str):
                         return content
                     if isinstance(content, list):
+                        text_parts: list[str] = []
                         for c in content:
                             c_dict = str_object_mapping(c)
                             if (
                                 c_dict is not None
                                 and c_dict.get("type") == "input_text"
                             ):
-                                text = c_dict.get("text", "")
+                                text = c_dict.get("text")
                                 if isinstance(text, str):
-                                    return text
-                            if isinstance(c, str):
-                                return c
+                                    text_parts.append(text)
+                            elif isinstance(c, str):
+                                text_parts.append(c)
+                        if text_parts:
+                            return " ".join(text_parts)
 
     if "contents" in kwargs:
         result = extract_from_contents(kwargs["contents"])

--- a/tests/llm/helpers/test_query_extraction.py
+++ b/tests/llm/helpers/test_query_extraction.py
@@ -32,6 +32,26 @@ def test_extract_openai_multimodal_returns_string_not_list():
     assert result == "Can you analyze this diagram? What does the top box say?"
 
 
+def test_extract_openai_responses_query_joins_all_input_text_parts():
+    kwargs = {
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "Plan a trip"},
+                    {
+                        "type": "input_image",
+                        "image_url": "https://example.com/map.png",
+                    },
+                    {"type": "input_text", "text": "to Kyoto in autumn"},
+                ],
+            }
+        ]
+    }
+
+    assert extract_user_query(kwargs) == "Plan a trip to Kyoto in autumn"
+
+
 def test_extract_text_from_parts_ignores_non_strings():
     """
     Behavioral Guarantee: The helper must never append non-strings to the


### PR DESCRIPTION
## What does this PR do?

OpenAI Responses requests can contain several `input_text` blocks in one user
item, often separated by image inputs. Memory recall currently uses only the
first block, while the model and persistence adapter receive the complete
message.

This change collects every valid `input_text` block, preserves their order,
ignores image inputs, and joins the text into the same query shape already used
by the OpenAI persistence adapter. The root cause was an early return inside
the multipart-content loop.

## Related issue

No linked issue; this boundary-condition defect was reproduced directly on
`main`.

## Before opening this PR

- [x] I have checked that there is not already an open PR for this change.
- [x] I have checked existing issues and discussions for relevant context.
- [x] I have read the contributing guidelines.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Test update
- [ ] Refactor or maintenance
- [ ] Performance improvement
- [ ] Build, CI, or release change

## Affected areas

- [x] Python SDK (`memori/`)
- [ ] TypeScript SDK (`memori-ts/`)
- [ ] Rust core or native bindings (`core/`)
- [x] LLM providers or adapters
- [ ] Storage adapters or drivers
- [x] Memory augmentation or recall
- [ ] Examples or integrations
- [x] Documentation
- [ ] CI, packaging, or tooling

## How was this tested?

- [x] `uv run pytest`
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [ ] `npm test` from `memori-ts/`
- [ ] `npm run lint` from `memori-ts/`
- [ ] Integration tests
- [ ] Manual testing

Regression evidence:

- The new focused test failed on unchanged `main`: expected
  `Plan a trip to Kyoto in autumn`, received `Plan a trip`.
- The same test passes with this fix.
- Affected Python suite: 93 passed.
- Full non-integration Python suite: 977 passed, 16 skipped.
- Ruff lint, Ruff format check, `ty`, Bandit, and `git diff --check` passed.

## Checklist

- [x] I have kept this change focused and consistent with the existing architecture.
- [x] I have added or updated tests where appropriate.
- [x] I have updated documentation or examples for user-facing changes.
- [x] This PR does not require live API keys for unit tests.
- [x] This PR does not include generated artifacts, local databases, or cache files.
- [x] I have called out any breaking changes, migration steps, or compatibility concerns below.

## Notes for reviewers

This is a compatible query-extraction correction with no dependency, public API,
or migration changes. The regression covers two text blocks separated by an
image block. Existing PR #505 addresses Chat Completions `messages[].content`;
this fix covers the distinct Responses `input[].content` path.
